### PR TITLE
Feat/implement json

### DIFF
--- a/enforceColor.js
+++ b/enforceColor.js
@@ -1,3 +1,0 @@
-// @ts-check
-export const colorUsed = process.env.OUTPUT_FORMAT !== 'JSON'
-if (!colorUsed) process.env.FORCE_COLOR = '0'

--- a/enforceColor.js
+++ b/enforceColor.js
@@ -1,0 +1,3 @@
+// @ts-check
+export const colorUsed = process.env.OUTPUT_FORMAT !== 'JSON'
+if (!colorUsed) process.env.FORCE_COLOR = '0'

--- a/index.js
+++ b/index.js
@@ -36,7 +36,10 @@ process.env.UPDATE_ALL = options.updateAll || ''
 
 if (options.format === 'json') process.env.OUTPUT_FORMAT = 'JSON'
 process.env.OUTPUT_FORMAT = process.env.OUTPUT_FORMAT || 'CONSOLE'
-if (process.env.OUTPUT_FORMAT === 'JSON') chalk.level = 0
+if (process.env.OUTPUT_FORMAT === 'JSON') {
+  chalk.level = 0
+  process.env.FORCE_COLOR = '0'
+}
 
 async function main () {
   const tmp = tempy.file({ extension: 'mjs' })

--- a/index.js
+++ b/index.js
@@ -129,7 +129,7 @@ async function main () {
 
     const tests = `${before}\n${func.tags.filter(i => i.type === 'test' || i.type === 'test_static').map((tag, index) => `
             ${beforeEach}
-            sum += await run(${JSON.stringify(tag.text)}, '${func.originalName || func.name}.${hash(func.relativePath + ':' + tag.text)}', ${wrapHof(func.alias, tag)}, "${func.fileName}")
+            sum += await run(${JSON.stringify(tag.text)}, '${func.originalName || func.name}.${hash(func.relativePath + ':' + tag.text)}', ${wrapHof(func.alias, tag)}, "${func.fileName}:${tag.lineNo}")
             ${afterEach}
         `).join('')}\n${after}`
 
@@ -247,7 +247,7 @@ function getFunctions (file, fileText, fileName) {
       .map(item => {
         const tags = item[1].filter(i => TAG_TYPES.includes(i.getTagName())).map(tag => {
           const tagName = tag.getTagName()
-          return { type: tagName, text: multiLine(fileText, tag.getStartLineNumber() - 1, tagName) }
+          return { type: tagName, text: multiLine(fileText, tag.getStartLineNumber() - 1, tagName), lineNo: tag.getStartLineNumber() }
         })
 
         return {
@@ -349,7 +349,8 @@ function getTags (fileText, end, tagTypes = TAG_TYPES) {
         if (new RegExp(`@${type}($| )`).test(fileText[end])) {
           tags.unshift({
             type,
-            text: multiLine(fileText, end, type)
+            text: multiLine(fileText, end, type),
+            lineNo: end + 1
           })
         }
       }

--- a/index.js
+++ b/index.js
@@ -4,15 +4,15 @@ import { Project } from 'ts-morph'
 import { groupBy, pluck, map, indexBy } from 'ramda'
 import tempy from 'tempy'
 
-import { program } from 'commander'
+import { program, Option } from 'commander'
 import { hash } from './hash.js'
 import url from 'url'
-import { colorUsed } from './enforceColor.js'
 import { transpile } from './typescriptTranspiler.js'
 import { parse } from './parser/dsl.js'
 import { skippingTest } from './outputs.js'
+import chalk from 'chalk'
 
-process.env.FORCE_COLOR = '0'
+const formatOption = new Option('-f, --format <format>', 'The output format').choices(['json', 'console']).default('console')
 
 program
   .name('pineapple')
@@ -21,6 +21,7 @@ program
   .option('-a, --accept-all', 'Accept all snapshots.')
   .option('-u, --update-all', 'Update all snapshots.')
   .option('-t, --typescript', 'Enables typescript (slower).')
+  .addOption(formatOption)
 
 program.parse()
 
@@ -31,8 +32,10 @@ if (!options.include || !options.include.length) throw new Error('Please select 
 // hack for now until I make the code better
 process.env.ACCEPT_ALL = options.acceptAll || ''
 process.env.UPDATE_ALL = options.updateAll || ''
+
+if (options.format === 'json') process.env.OUTPUT_FORMAT = 'JSON'
 process.env.OUTPUT_FORMAT = process.env.OUTPUT_FORMAT || 'CONSOLE'
-process.env.COLOR_USED = colorUsed.toString()
+if (process.env.OUTPUT_FORMAT === 'JSON') chalk.level = 0
 
 async function main () {
   const tmp = tempy.file({ extension: 'mjs' })

--- a/inputs.js
+++ b/inputs.js
@@ -5,10 +5,10 @@ import { diff } from './utils.js'
 
 /**
  * It asks the user if they want to accept the snapshot
- * @param {{ item: any, rule: string, id: string }} data
+ * @param {{ item: any, rule: string, id: string, file: string }} data
  * @returns A function that returns a boolean.
  */
-export async function askSnapshot ({ item, rule, id }) {
+export async function askSnapshot ({ item, rule, id, file }) {
   if (process.env.CI) return false
   if (process.env.ACCEPT_ALL) return true
   if (process.env.OUTPUT_FORMAT === 'JSON') {
@@ -16,7 +16,8 @@ export async function askSnapshot ({ item, rule, id }) {
       type: 'Request Snapshot',
       item,
       input: rule,
-      id
+      id,
+      file
     }))
     return false
   }
@@ -28,10 +29,10 @@ export async function askSnapshot ({ item, rule, id }) {
 
 /**
  * It asks the user if they want to update the snapshot
- * @param {{ item: any, rule: string, id: string, value: any }} data
+ * @param {{ item: any, rule: string, id: string, value: any, file: string }} data
  * @returns A function that returns a boolean.
  */
-export async function askSnapshotUpdate ({ item, value, rule, id }) {
+export async function askSnapshotUpdate ({ item, value, rule, id, file }) {
   if (process.env.CI) return false
   if (process.env.UPDATE_ALL) return true
   if (process.env.OUTPUT_FORMAT === 'JSON') {
@@ -40,7 +41,8 @@ export async function askSnapshotUpdate ({ item, value, rule, id }) {
       new: item,
       old: value,
       input: rule,
-      id
+      id,
+      file
     }))
     return false
   }

--- a/inputs.js
+++ b/inputs.js
@@ -1,0 +1,32 @@
+import chalk from 'chalk'
+import inquirer from 'inquirer'
+import { serialize } from './snapshot.js'
+import { diff } from './utils.js'
+
+/**
+ * It asks the user if they want to accept the snapshot
+ * @param {{ item: any, rule: string, id: string }} data
+ * @returns A function that returns a boolean.
+ */
+export async function askSnapshot ({ item, rule, id }) {
+  if (process.env.CI) return false
+  if (process.env.ACCEPT_ALL) return true
+  console.log(`On test (${id.split('(')[0]}):`, rule)
+  console.log(chalk.green(serialize(item)))
+  const { result } = await inquirer.prompt([{ name: 'result', message: 'Accept this snapshot?', type: 'list', choices: ['Yes', 'No'] }])
+  return result === 'Yes'
+}
+
+/**
+ * It asks the user if they want to update the snapshot
+ * @param {{ item: any, rule: string, id: string, value: any }} data
+ * @returns A function that returns a boolean.
+ */
+export async function askSnapshotUpdate ({ item, value, rule, id }) {
+  if (process.env.CI) return false
+  if (process.env.UPDATE_ALL) return true
+  console.log(`On test (${id.split('(')[0]}):`, rule)
+  console.log(diff(value, item))
+  const { result } = await inquirer.prompt([{ name: 'result', message: 'Do you wish to update to this snapshot?', type: 'list', choices: ['Yes', 'No'] }])
+  return result === 'Yes'
+}

--- a/inputs.js
+++ b/inputs.js
@@ -11,6 +11,15 @@ import { diff } from './utils.js'
 export async function askSnapshot ({ item, rule, id }) {
   if (process.env.CI) return false
   if (process.env.ACCEPT_ALL) return true
+  if (process.env.OUTPUT_FORMAT === 'JSON') {
+    console.log(JSON.stringify({
+      type: 'Request Snapshot',
+      item,
+      input: rule,
+      id
+    }))
+    return false
+  }
   console.log(`On test (${id.split('(')[0]}):`, rule)
   console.log(chalk.green(serialize(item)))
   const { result } = await inquirer.prompt([{ name: 'result', message: 'Accept this snapshot?', type: 'list', choices: ['Yes', 'No'] }])
@@ -25,6 +34,16 @@ export async function askSnapshot ({ item, rule, id }) {
 export async function askSnapshotUpdate ({ item, value, rule, id }) {
   if (process.env.CI) return false
   if (process.env.UPDATE_ALL) return true
+  if (process.env.OUTPUT_FORMAT === 'JSON') {
+    console.log(JSON.stringify({
+      type: 'Request Snapshot Update',
+      new: item,
+      old: value,
+      input: rule,
+      id
+    }))
+    return false
+  }
   console.log(`On test (${id.split('(')[0]}):`, rule)
   console.log(diff(value, item))
   const { result } = await inquirer.prompt([{ name: 'result', message: 'Do you wish to update to this snapshot?', type: 'list', choices: ['Yes', 'No'] }])

--- a/methods.js
+++ b/methods.js
@@ -82,12 +82,10 @@ engine.addMethod('snapshot', async ([inputs], context) => {
 
   // @ts-ignore
   result.async = promise
-  // result.hash = context.hash
-
   const { exists, value } = await context.snap.find(context.id)
 
   // @ts-ignore
-  if ((!exists || !equals(value.hash, result.hash)) && await askSnapshot({ item: result, rule: context.rule, id: context.id })) {
+  if (!exists && await askSnapshot({ item: result, rule: context.rule, id: context.id })) {
     await context.snap.set(context.id, result)
     return [result, true]
   }
@@ -102,9 +100,10 @@ engine.addMethod('snapshot', async ([inputs], context) => {
       await context.snap.set(context.id, result)
       return [result, true]
     }
+    return [result, false, diff(value, result)]
   }
 
-  return [result, false, diff(value, result)]
+  return [result, false, 'There is no snapshot for this test.']
 }, {
   useContext: true
 })

--- a/methods.js
+++ b/methods.js
@@ -1,30 +1,15 @@
 // @ts-check
 import { AsyncLogicEngine, Compiler } from 'json-logic-engine'
-import { splitEvery, equals, omit } from 'ramda'
-import { diff } from 'jest-diff'
+import { splitEvery, equals } from 'ramda'
 import Ajv from 'ajv'
-import inquirer from 'inquirer'
 import chalk from 'chalk'
 import { SpecialHoF } from './symbols.js'
+import { askSnapshotUpdate, askSnapshot } from './inputs.js'
+import { diff } from './utils.js'
 import { serialize } from './snapshot.js'
 
 const engine = new AsyncLogicEngine()
 const ajv = new Ajv()
-
-/**
- * It takes the output of the diff function and if it contains the string "Comparing two different
- * types", it replaces the output with a more detailed message
- * @param expected - The expected value.
- * @param received - The value that was actually returned from the test.
- * @returns The function diffTouchup is being returned.
- */
-function diffTouchup (expected, received) {
-  const result = diff(expected, received)
-  if (result.includes('Comparing two different types')) {
-    return `${result}\n  ${chalk.green(`- Expected: ${stringify(expected).replace(/\n/g, '\n  ')}`)}\n${chalk.red(`  - Received: ${stringify(received).replace(/\n/g, '\n  ')}`)}`
-  }
-  return result
-}
 
 engine.addMethod('===', ([a, b]) => equals(a, b), {
   sync: true,
@@ -77,42 +62,6 @@ function generateErrorText (error) {
   return chalk.red(JSON.stringify(error))
 }
 
-/**
- * It converts an object to a string, replacing undefined values with the string 'undefined'
- * @param obj - The object to stringify
- */
-function stringify (obj) {
-  return serialize(obj)
-}
-
-/**
- * It asks the user if they want to accept the snapshot
- * @param {{ item: any, rule: string, id: string }} data
- * @returns A function that returns a boolean.
- */
-async function askSnapshot ({ item, rule, id }) {
-  if (process.env.CI) return false
-  if (process.env.ACCEPT_ALL) return true
-  console.log(`On test (${id.split('(')[0]}):`, rule)
-  console.log(chalk.green(stringify(omit(['hash'], item))))
-  const { result } = await inquirer.prompt([{ name: 'result', message: 'Accept this snapshot?', type: 'list', choices: ['Yes', 'No'] }])
-  return result === 'Yes'
-}
-
-/**
- * It asks the user if they want to update the snapshot
- * @param {{ item: any, rule: string, id: string, value: any }} data
- * @returns A function that returns a boolean.
- */
-async function askSnapshotUpdate ({ item, value, rule, id }) {
-  if (process.env.CI) return false
-  if (process.env.UPDATE_ALL) return true
-  console.log(`On test (${id.split('(')[0]}):`, rule)
-  console.log(diff(omit(['hash'], value), omit(['hash'], item)))
-  const { result } = await inquirer.prompt([{ name: 'result', message: 'Do you wish to update to this snapshot?', type: 'list', choices: ['Yes', 'No'] }])
-  return result === 'Yes'
-}
-
 engine.addMethod('snapshot', async ([inputs], context) => {
   let result = null
   let promise = false
@@ -140,22 +89,22 @@ engine.addMethod('snapshot', async ([inputs], context) => {
   // @ts-ignore
   if ((!exists || !equals(value.hash, result.hash)) && await askSnapshot({ item: result, rule: context.rule, id: context.id })) {
     await context.snap.set(context.id, result)
-    return [omit(['hash'], result), true]
+    return [result, true]
   }
 
   if (equals(value, result)) {
-    return [omit(['hash'], result), true]
+    return [result, true]
   }
 
   if (exists) {
     // We have a snapshot, but it's different, so we need to ask the user if they want to update the snapshot
     if (await askSnapshotUpdate({ item: result, value, rule: context.rule, id: context.id })) {
       await context.snap.set(context.id, result)
-      return [omit(['hash'], result), true]
+      return [result, true]
     }
   }
 
-  return [omit(['hash'], result), false, diff(omit(['hash'], value), omit(['hash'], result))]
+  return [result, false, diff(value, result)]
 }, {
   useContext: true
 })
@@ -165,13 +114,13 @@ engine.addMethod('to', async ([inputs, output], context) => {
     const result = getDataSpecial(context.func.apply(null, inputs))
     if (!equals(result, output)) {
       if (result && result.then) {
-        return [await result, false, `Expected ${JSON.stringify(output)} but got Promise<${JSON.stringify(await result)}>`]
+        return [await result, false, `Expected ${chalk.green(`${serialize(output)} `)}\n\nReceived ${chalk.red(`Promise<${serialize(await result)}>`)}`]
       }
-      return [result, false, diffTouchup(output, result)]
+      return [result, false, diff(output, result)]
     }
     return [result, true]
   } catch (err) {
-    return [err, false, `Expected ${JSON.stringify(output)} but function threw ${generateErrorText(err)}`]
+    return [err, false, `Expected ${chalk.green(serialize(output))} but function threw ${chalk.red(generateErrorText(err))}`]
   }
 }, {
   useContext: true
@@ -205,10 +154,18 @@ engine.addMethod('toParse', {
 engine.addMethod('resolves', async ([inputs, output], context) => {
   try {
     const result = getDataSpecial(context.func.apply(null, inputs))
-    if (!result || !result.then) return [result, false, 'Was not a promise.']
-    return [await result, equals(await result, output)]
+
+    if (!result || !result.then) {
+      return [await result, false, `Expected ${chalk.green(`Promise<${serialize(output)}>`)}\n\nReceived ${chalk.red(`${serialize(await result)}`)}`]
+    }
+
+    if (!equals(await result, output)) {
+      return [result, false, diff(output, await result)]
+    }
+
+    return [await result, true]
   } catch (err) {
-    return [err, false, `Expected ${JSON.stringify(output)} but function rejected with ${generateErrorText(err)}`]
+    return [err, false, `Expected ${serialize(output)} but function rejected with ${generateErrorText(err)}`]
   }
 }, {
   useContext: true
@@ -249,18 +206,16 @@ engine.addMethod('throws', async ([inputs, output], context) => {
 
     if (result && result.then) {
       try {
-        return [await result, false, `Expected to throw but got Promise<${JSON.stringify(await result)}>`]
+        return [await result, false, `Expected to throw but got ${chalk.red(`Promise<${serialize(await result)}>`)}`]
       } catch (err2) {
-        return [err2, false, `Expected to throw but got rejected Promise instead. (${err2 && (err2.message || err2.constructor.name || err2)})`]
+        return [err2, false, `Expected to throw but got rejected Promise instead. (${chalk.red(err2 && (err2.message || err2.constructor.name || err2))})`]
       }
     }
     return [result, false, 'Did not throw.']
   } catch (err) {
     const errorName = err.constructor.name
     const errorMessage = err.message
-
     if (output && !equals(errorName, output) && !equals(errorMessage, output)) { return [err, false, `Error name or message did not match. Expected '${output}' but got class '${errorName}' or message '${errorMessage}'`] }
-
     return [err, true]
   }
 })

--- a/methods.js
+++ b/methods.js
@@ -85,7 +85,7 @@ engine.addMethod('snapshot', async ([inputs], context) => {
   const { exists, value } = await context.snap.find(context.id)
 
   // @ts-ignore
-  if (!exists && await askSnapshot({ item: result, rule: context.rule, id: context.id })) {
+  if (!exists && await askSnapshot({ item: result, rule: context.rule, id: context.id, file: context.file })) {
     await context.snap.set(context.id, result)
     return [result, true]
   }
@@ -96,7 +96,7 @@ engine.addMethod('snapshot', async ([inputs], context) => {
 
   if (exists) {
     // We have a snapshot, but it's different, so we need to ask the user if they want to update the snapshot
-    if (await askSnapshotUpdate({ item: result, value, rule: context.rule, id: context.id })) {
+    if (await askSnapshotUpdate({ item: result, value, rule: context.rule, id: context.id, file: context.file })) {
       await context.snap.set(context.id, result)
       return [result, true]
     }

--- a/outputs.js
+++ b/outputs.js
@@ -1,0 +1,89 @@
+import chalk from 'chalk'
+import logSymbols from 'log-symbols'
+
+const format = text => text.includes('\n') ? `\n${text}\n` : text
+
+/**
+ * Announces that a test is being skipped due to it not being exported.
+ * @param {string} name
+ * @param {string} file
+ */
+export function skippingTest (name, file) {
+  if (process.env.OUTPUT_FORMAT === 'CONSOLE') {
+    return console.warn(logSymbols.warning, `Function / Class "${name}" is not exported from ${file}, skipping its tests.`)
+  }
+
+  if (process.env.OUTPUT_FORMAT === 'JSON') {
+    return console.warn(JSON.stringify({ type: 'Test Skipped', name, file }))
+  }
+}
+
+/**
+ * Announces that a test was successful.
+ * @param {string} name
+ * @param {string} input
+ * @param {string} file
+ */
+export function success (name, input, file) {
+  if (process.env.OUTPUT_FORMAT === 'CONSOLE') {
+    console.log(logSymbols.success, `Passed test (${name}):`, format(input))
+  }
+
+  if (process.env.OUTPUT_FORMAT === 'JSON') {
+    return console.log(JSON.stringify({ type: 'Success', name, input, file }))
+  }
+}
+
+/**
+ * Announces that a test was not successful.
+ * @param {string} name
+ * @param {string} input
+ * @param {string} message
+ * @param {string} file
+ */
+export function failure (name, input, message, file) {
+  if (process.env.OUTPUT_FORMAT === 'CONSOLE') {
+    console.log(logSymbols.error, `Failed test (${name}):`, format(input))
+    if (message) {
+      console.log(message)
+      console.log()
+    }
+  }
+
+  if (process.env.OUTPUT_FORMAT === 'JSON') {
+    return console.log(JSON.stringify({ type: 'Failure', name, input, message, file }))
+  }
+}
+
+/**
+ * Announces that a test could not be run because of a parse failure.
+ * @param {string} name
+ * @param {string} input
+ * @param {string} message
+ * @param {string} file
+ */
+export function parseFailure (name, input, message, file) {
+  if (process.env.OUTPUT_FORMAT === 'CONSOLE') {
+    console.log(logSymbols.error, `Could not parse on (${name}): ${input}`)
+    console.log(chalk.red(message))
+    console.log()
+  }
+
+  if (process.env.OUTPUT_FORMAT === 'JSON') {
+    return console.log(JSON.stringify({ type: 'ParseFailure', name, input, message, file }))
+  }
+}
+
+/**
+ * Tries to log a test runtime error
+ * @param {*} err
+ */
+export function testRuntimeFailure (err) {
+  if (process.env.OUTPUT_FORMAT === 'CONSOLE') {
+    console.error(err)
+  }
+
+  if (process.env.OUTPUT_FORMAT === 'JSON') {
+    return console.log(JSON.stringify({ type: 'RuntimeFailure', message: err.message, name: err.name || (err.constructor || {}).name || 'Unidentified Error' }))
+  }
+}

--- a/outputs.js
+++ b/outputs.js
@@ -44,6 +44,7 @@ export function success (name, input, file) {
 export function failure (name, input, message, file) {
   if (process.env.OUTPUT_FORMAT === 'CONSOLE') {
     console.log(logSymbols.error, `Failed test (${name}):`, format(input))
+    console.log('>>', file)
     if (message) {
       console.log(message)
       console.log()

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "prepublish": "npm run build",
     "build": "npm run generate:parser",
-    "generate:parser": "peggy --allowed-start-rules Document,Expression --cache --format es -o parser/dsl.js parser/grammar.pegjs && cd parser && exitzero standard --fix *.js",
+    "generate:parser": "peggy --allowed-start-rules Document,Expression --cache --format es -o parser/dsl.js parser/grammar.pegjs && cd parser && exitzero standard --fix *.js && node patch.js",
     "test": "c8 node index.js -i \"test/*,*.js\" -t"
   },
   "repository": {

--- a/parser/patch.js
+++ b/parser/patch.js
@@ -1,0 +1,9 @@
+// Patches the parser code so that it doesn't get evaluated by c8.
+
+import fs from 'fs'
+
+fs.writeFileSync('./dsl.js',
+`/* c8 ignore start */
+${fs.readFileSync('./dsl.js').toString()}
+/* c8 ignore end */`
+)

--- a/run.js
+++ b/run.js
@@ -2,9 +2,7 @@
 import engine from './methods.js'
 import { parse } from './parser/dsl.js'
 import { snapshot } from './snapshot.js'
-import logSymbols from 'log-symbols'
 import { hash } from './hash.js'
-import chalk from 'chalk'
 import { SpecialHoF } from './symbols.js'
 import { failure, parseFailure, success, testRuntimeFailure } from './outputs.js'
 const snap = snapshot()
@@ -32,9 +30,9 @@ export async function execute (input) {
  * @param {string} input
  * @param {string} id
  * @param {(...args: any[]) => any} func
- * @param {string} fileName
+ * @param {string} file
  */
-export async function run (input, id, func, fileName) {
+export async function run (input, id, func, file) {
   const [idName, idHash] = id.split('.')
 
   /**
@@ -55,7 +53,7 @@ export async function run (input, id, func, fileName) {
       }
       const [current] = result
       if (typeof result[0] !== 'function') return [result[0], false, 'Does not return a function.']
-      result = await engine.run(step, { func: current, id: (`${idName}(${input}) [${idHash}]`), snap, hash: h, rule: input })
+      result = await engine.run(step, { func: current, id: (`${idName}(${input}) [${idHash}]`), snap, hash: h, rule: input, file })
       const [data, success, message] = result
       if (!success) return [data, false, message]
       // Special Override for the Class-Based HoF thing.
@@ -71,19 +69,19 @@ export async function run (input, id, func, fileName) {
     const [, success, message] = await internalRun(input, id, func)
 
     if (!success) {
-      failure(idName, input, message, fileName)
+      failure(idName, input, message, file)
       return 1
     }
   } catch (err) {
     if (err.expected) {
       const { message } = err
-      parseFailure(idName, input, message, fileName)
+      parseFailure(idName, input, message, file)
     } else testRuntimeFailure(err)
 
     return 1
   }
 
-  success(idName, input, fileName)
+  success(idName, input, file)
   return 0
 }
 

--- a/run.js
+++ b/run.js
@@ -6,6 +6,7 @@ import logSymbols from 'log-symbols'
 import { hash } from './hash.js'
 import chalk from 'chalk'
 import { SpecialHoF } from './symbols.js'
+import { failure, parseFailure, success, testRuntimeFailure } from './outputs.js'
 const snap = snapshot()
 
 /**
@@ -31,8 +32,9 @@ export async function execute (input) {
  * @param {string} input
  * @param {string} id
  * @param {(...args: any[]) => any} func
+ * @param {string} fileName
  */
-export async function run (input, id, func) {
+export async function run (input, id, func, fileName) {
   const [idName, idHash] = id.split('.')
 
   /**
@@ -65,31 +67,23 @@ export async function run (input, id, func) {
     return result
   }
 
-  const format = text => text.includes('\n') ? `\n${text}\n` : text
-
   try {
     const [, success, message] = await internalRun(input, id, func)
 
     if (!success) {
-      console.log(logSymbols.error, `Failed test (${idName}):`, format(input))
-      if (message) {
-        console.log(message)
-        console.log()
-      }
+      failure(idName, input, message, fileName)
       return 1
     }
   } catch (err) {
     if (err.expected) {
       const { message } = err
-      console.log(logSymbols.error, `Could not parse on (${idName}): ${input}`)
-      console.log(chalk.red(message))
-      console.log()
-    } else console.log(err)
+      parseFailure(idName, input, message, fileName)
+    } else testRuntimeFailure(err)
 
     return 1
   }
 
-  console.log(logSymbols.success, `Passed test (${idName}):`, format(input))
+  success(idName, input, fileName)
   return 0
 }
 

--- a/test/setup.test.js
+++ b/test/setup.test.js
@@ -12,7 +12,7 @@ export function isPrime (n) {
 }
 
 /**
- * @test undefined returns isPrime(@)
+ * @test void returns isPrime(@)
  */
 export function generatePrime () {
   return 17

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,18 @@
+import chalk from 'chalk'
+import { diff as jestDiff } from 'jest-diff'
+import { serialize } from './snapshot.js'
+
+/**
+ * It takes the output of the diff function and if it contains the string "Comparing two different
+ * types", it replaces the output with a more detailed message
+ * @param expected - The expected value.
+ * @param received - The value that was actually returned from the test.
+ * @returns The function diffTouchup is being returned.
+ */
+export function diff (expected, received) {
+  const result = jestDiff(expected, received)
+  if (result.includes('Comparing two different types')) {
+    return `${result}\n  ${chalk.green(`- Expected: ${serialize(expected).replace(/\n/g, '\n  ')}`)}\n${chalk.red(`  - Received: ${serialize(received).replace(/\n/g, '\n  ')}`)}`
+  }
+  return result
+}


### PR DESCRIPTION
This PR introduces the ability to export to NDJSON which is useful for things like editor integrations.

```
{"type":"Success","name":"fib","input":"1","file":"file:///Users/jesse/Documents/Projects/pineapple/test/math.js:39"}
{"type":"Success","name":"fib","input":"3","file":"file:///Users/jesse/Documents/Projects/pineapple/test/math.js:40"}
{"type":"Success","name":"fib","input":"10","file":"file:///Users/jesse/Documents/Projects/pineapple/test/math.js:41"}
{"type":"Success","name":"add","input":"1, 2","file":"file:///Users/jesse/Documents/Projects/pineapple/test/math.js:2"}
{"type":"Success","name":"add","input":"'4', 3 throws","file":"file:///Users/jesse/Documents/Projects/pineapple/test/math.js:3"}
{"type":"Success","name":"add","input":"1, '0' throws","file":"file:///Users/jesse/Documents/Projects/pineapple/test/math.js:4"}
{"type":"Success","name":"add","input":"-1, 1","file":"file:///Users/jesse/Documents/Projects/pineapple/test/math.js:5"}
{"type":"Success","name":"add","input":"-1, 1 to 0","file":"file:///Users/jesse/Documents/Projects/pineapple/test/math.js:6"}
{"type":"Failure","name":"add","input":"-1, 1 to -1","message":"- Expected\n+ Received\n\n- -1\n+ 0","file":"file:///Users/jesse/Documents/Projects/pineapple/test/math.js:7"}
{"type":"Success","name":"add","input":"-1, -1 to -2","file":"file:///Users/jesse/Documents/Projects/pineapple/test/math.js:8"}
{"type":"Failure","name":"add","input":"-1, '-1' to -2","message":"Expected -2 but function threw \"Not numbers\"","file":"file:///Users/jesse/Documents/Projects/pineapple/test/math.js:9"}
```

It is most easily accessible through the `-f json` flag, but you may also set the environment variable `OUTPUT_FORMAT=JSON`.

This PR also introduces the ability to run a subset of tests by using the `--only` flag, which allows you to pass in the filepath & line number that you'd like.

Ex.
`--only file:///Users/jesse/Documents/Projects/pineapple/test/math.js:2`

Right now, if an integration were pursued, it's mildly clunky to set up snapshots, you'd have to chain the two flags `-a --only testCase`, but it'd work :) 