### PR TITLE
Feat/implement pbt

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ const formatOption = new Option('-f, --format <format>', 'The output format').ch
 
 program
   .name('pineapple')
-  .version('0.8.0')
+  .version('0.9.0')
   .option('-i, --include <files...>', 'Comma separated globs of files.')
   .option('-a, --accept-all', 'Accept all snapshots.')
   .option('-u, --update-all', 'Update all snapshots.')
@@ -74,7 +74,7 @@ async function main () {
 
   testFile.addImportDeclaration({
     moduleSpecifier: specifier.join('/'),
-    namedImports: ['run', 'addMethod', 'execute', 'hof'],
+    namedImports: ['run', 'addMethod', 'addDefinitions', 'execute', 'hof'],
     isTypeOnly: false
   })
 
@@ -102,6 +102,8 @@ async function main () {
   const { addedMethods, tests, beforeAll, afterAll } = functions.map(func => {
     const addedMethods = func.tags.filter(i => i.type === 'pineapple_import').map(i => {
       return `addMethod(${JSON.stringify(i.text || func.originalName || func.name)}, ${func.alias})\n`
+    }).join('') + '\n' + func.tags.filter(i => i.type === 'pineapple_define').map(() => {
+      return `addDefinitions(${func.alias})\n`
     }).join('')
 
     const beforeAll = func.tags.filter(i => i.type === 'beforeAll').map(i => {
@@ -164,6 +166,7 @@ const TAG_TYPES = [
   'test',
   'test_static',
   'pineapple_import',
+  'pineapple_define',
   'beforeAll',
   'afterAll',
   'before',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pineapple",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "A testing framework for humans.",
   "main": "index.js",
   "scripts": {
@@ -19,6 +19,7 @@
     "ajv": "^8.11.0",
     "chalk": "^5.0.1",
     "commander": "^9.2.0",
+    "fast-check": "^2.25.0",
     "inquirer": "^8.2.2",
     "jest-diff": "^27.5.1",
     "json-logic-engine": "^1.1.19",

--- a/parser/grammar.pegjs
+++ b/parser/grammar.pegjs
@@ -173,7 +173,7 @@ Operator
 
 Operands
   = 
-    _ "$." call:FunctionCall { const key = Object.keys(call)[0]; const result = [key, ...[].concat(call[key])]; result.special = true; return [result] }
+    _ "$." call:FunctionCall { const key = Object.keys(call)[0]; const result = [key, ...[].concat(call[key])]; result.special = true; return result }
   / _ exp:Expression _ "," _ tail:Operands { return [exp, ...tail] }
   / _ exp:Expression { return [ exp ]; }
   

--- a/parser/grammar.pegjs
+++ b/parser/grammar.pegjs
@@ -135,7 +135,7 @@ TestExpressionLayered = a:TestExpression "~>" b:TestExpressionLayered {
 
 TestExpression = 
      ops:Operands _req ("resolves to" / "resolves") _req result:Expression _ { 
-      if (traverse(result, i => i && typeof i.var !== 'undefined' && i.var.startsWith('data'))) {
+      if (traverse(result, i => i && typeof i.var !== 'undefined' && (i.var.startsWith('data') || i.var.startsWith('context')))) {
         return {
           resolvesParse: [ops, result]
         }
@@ -143,7 +143,7 @@ TestExpression =
       return { resolves: [ops, result] } 
   }
   /  ops:Operands _req ("to" / "is" / "returns") _req result:Expression _ { 
-      if (traverse(result, i => i && typeof i.var !== 'undefined' && i.var.startsWith('data'))) {
+      if (traverse(result, i => i && typeof i.var !== 'undefined' && (i.var.startsWith('data') || i.var.startsWith('context')))) {
         return {
           toParse: [ops, result]
         }

--- a/parser/grammar.pegjs
+++ b/parser/grammar.pegjs
@@ -135,7 +135,7 @@ TestExpressionLayered = a:TestExpression "~>" b:TestExpressionLayered {
 
 TestExpression = 
      ops:Operands _req ("resolves to" / "resolves") _req result:Expression _ { 
-      if (traverse(result, i => i && typeof i.var !== 'undefined')) {
+      if (traverse(result, i => i && typeof i.var !== 'undefined' && i.var.startsWith('data'))) {
         return {
           resolvesParse: [ops, result]
         }
@@ -143,7 +143,7 @@ TestExpression =
       return { resolves: [ops, result] } 
   }
   /  ops:Operands _req ("to" / "is" / "returns") _req result:Expression _ { 
-      if (traverse(result, i => i && typeof i.var !== 'undefined')) {
+      if (traverse(result, i => i && typeof i.var !== 'undefined' && i.var.startsWith('data'))) {
         return {
           toParse: [ops, result]
         }
@@ -223,6 +223,7 @@ NonArithmeticExpression
   / Numeric
   / VarIdentifier
   / ContextIdentifier
+  / ArgsIdentifier
   / String
   / FunctionCall
   / Infinity
@@ -275,6 +276,12 @@ ArithmeticExpression0
 FunctionCall
   = _ id:Identifier _ '(' _ args:FunctionArgs _ ').' getId:Identifier {
     return { get: [{ [id]: args.length <= 1 ? args[0] : args }, getId] }
+  }
+  / _ '#' id:Identifier _ '(' _ args:FunctionArgs _ ')' {
+    return { ['#' + id]: args.length <= 1 ? args[0] : args }
+  }
+  / _ '#' id:Identifier {
+    return { ['#' + id]: undefined }
   } 
   / _ id:Identifier _ '(' _ args:FunctionArgs _ ')' {
     return { [id]: args.length <= 1 ? args[0] : args }
@@ -343,6 +350,9 @@ VarIdentifier "@-identifier"
 ContextIdentifier "$-identifier"
   = '$.' id:MemberIdentifier { return { var: `context.${id}` } }
   / "$" { return { var: 'context' } }
+ArgsIdentifier "args-identifier"
+  = 'args.' id:MemberIdentifier { return { var: `args.${id}` } }
+  / "args" { return { var: 'args' } }
 MemberIdentifier "member-identifier"
   = Identifier
   / Integer { return text() }

--- a/run.js
+++ b/run.js
@@ -1,10 +1,13 @@
 /* eslint-disable no-prototype-builtins */
 import engine from './methods.js'
 import { parse } from './parser/dsl.js'
-import { snapshot } from './snapshot.js'
+import { serialize, snapshot } from './snapshot.js'
 import { hash } from './hash.js'
-import { SpecialHoF } from './symbols.js'
+import { SpecialHoF, ConstantFunc } from './symbols.js'
 import { failure, parseFailure, success, testRuntimeFailure } from './outputs.js'
+import fc from 'fast-check'
+import { argumentsToArbitraries } from './utils.js'
+import { always } from 'ramda'
 const snap = snapshot()
 
 /**
@@ -17,12 +20,48 @@ export function addMethod (name, fn) {
 }
 
 /**
+ * Executes the method passed in, and adds the arbitraries to the engine.
+ * @param {(...args: any[]) => ({ [key: string]: any })} fn
+ */
+export function addDefinitions (fn) {
+  const definitions = fn()
+  Object.keys(definitions).forEach(key => {
+    if (typeof definitions[key] === 'function') {
+      const method = definitions[key]
+      engine.addMethod('#' + key, (data) => {
+        if (data === undefined) return method()
+        return method(...[].concat(data))
+      }, { sync: true })
+    } else {
+      const arbitrary = definitions[key]
+      if (arbitrary instanceof fc.Arbitrary) {
+        engine.addMethod('#' + key, always(arbitrary), { sync: true })
+      } else {
+        const func = always(fc.constant(arbitrary))
+        func[ConstantFunc] = true
+        engine.addMethod('#' + key, func, { sync: true })
+      }
+    }
+  })
+}
+
+/**
  * Just executes the expression, used for "before" / "beforeEach" / "after" / "afterEach".
  * @param {string} input
  */
 export async function execute (input) {
   const ast = parse(input, { startRule: 'Expression' })
   await engine.run(ast)
+}
+
+class FuzzError extends Error {
+  constructor (counterExample, seed, message, shrunk) {
+    super()
+    this.counterExample = counterExample
+    this.seed = seed
+    this.shrunk = shrunk
+    this.message = message
+  }
 }
 
 /**
@@ -46,6 +85,7 @@ export async function run (input, id, func, file) {
     const h = hash(input)
     let result = [func]
     let lastSpecial = false
+
     for (const step of script) {
       // Override to break the special "hof" class thing.
       if (lastSpecial) {
@@ -53,9 +93,40 @@ export async function run (input, id, func, file) {
       }
       const [current] = result
       if (typeof result[0] !== 'function') return [result[0], false, 'Does not return a function.']
-      result = await engine.run(step, { func: current, id: (`${idName}(${input}) [${idHash}]`), snap, hash: h, rule: input, file })
+
+      const key = Object.keys(step)[0]
+      const [inputs, expectation] = step[key]
+      const arbs = await argumentsToArbitraries(...inputs)
+      let failed = null
+      try {
+        let count = 0
+        await fc.assert(fc.asyncProperty(...arbs, async (...args) => {
+          count++
+          const countStr = count > 1 ? `.${count}` : ''
+          result = await engine.run({
+            [key]: [{ preserve: args }, expectation]
+          }, { func: current, id: (`${idName}(${input}) [${idHash}${countStr}]`), snap, hash: h, rule: input, file, args, context: current.instance, fuzzed: !arbs.constant })
+          if (!result[1]) failed = result
+          return result[1]
+        }), {
+          seed: key === 'snapshot' ? parseInt(h.substring(0, 16), 16) : undefined,
+          numRuns: arbs.constant ? 1 : key === 'snapshot' ? 10 : undefined,
+          reporter (out) {
+            if (out.failed) {
+              throw new FuzzError(out.counterexample, out.seed, out.error, out.numShrinks)
+            }
+          }
+        })
+      } catch (e) {
+        if (e instanceof FuzzError && !arbs.constant) {
+          failed[2] = (failed[2] || '') + `\nFailing Example: ${serialize(e.counterExample)}\nShrunk ${e.shrunk} times.\nSeed: ${e.seed}`
+        }
+      }
+
       const [data, success, message] = result
+      if (failed) return failed
       if (!success) return [data, false, message]
+
       // Special Override for the Class-Based HoF thing.
       if (current[SpecialHoF]) {
         if (typeof result[0] !== 'function') result[0] = current

--- a/run.js
+++ b/run.js
@@ -164,7 +164,7 @@ export async function run (input, id, func, file) {
 export function hof (ClassToUse, staticClass = false) {
   return (...args) => {
     const instance = staticClass ? ClassToUse : new ClassToUse(...args)
-    const f = ([method, ...args]) => {
+    const f = (method, ...args) => {
       if (!(method in instance && (instance.hasOwnProperty(method) || ClassToUse.prototype.hasOwnProperty(method)))) { throw new Error(`'${method}' is not a method of '${ClassToUse.name}'`) }
       f.result = instance[method](...args)
       return f

--- a/symbols.js
+++ b/symbols.js
@@ -1,1 +1,2 @@
 export const SpecialHoF = Symbol('SpecialHoF')
+export const ConstantFunc = Symbol('ConstantFunc')

--- a/test/fuzz.js
+++ b/test/fuzz.js
@@ -26,3 +26,15 @@ export function drinkingAge ({ name, age }) {
 export function isSquare (num) {
   return Math.sqrt(num) % 1 === 0
 }
+
+/**
+ * A simple template function.
+ * @test 'Hello $0' ~> 'World' returns 'Hello World'
+ * @test '$0 $0' ~> 'Hi' returns 'Hi Hi'
+ * @test 'Hello $0' ~> #string returns cat('Hello ', args.0)
+ * @param {string} templateString
+ */
+export function template (templateString) {
+  /** @param {string} replace */
+  return replace => templateString.replace(/\$0/g, replace.replace(/\$/g, '$$$$'))
+}

--- a/test/fuzz.js
+++ b/test/fuzz.js
@@ -1,0 +1,28 @@
+/**
+ * @test #array(#integer) returns @ as number
+ * @test #array(#string, { minLength: 1 }) throws
+ * @test [1, 2, 3] returns 6
+ * @test [#integer, 2, 3] returns args.0.0 + 5
+ * @test [] returns 0
+ */
+export function sum (values) {
+  if (values.some(i => typeof i !== 'number')) throw new Error('An item in the array is not a number.')
+  return values.reduce((a, b) => a + b, 0)
+}
+
+/**
+ * @test { name: #string, age: #integer(1, 20) } throws
+ * @test { name: 'Jesse', age: #integer(21, 80) } returns cat(args.0.name, ' is drinking age.')
+ */
+export function drinkingAge ({ name, age }) {
+  if (age >= 21) return `${name} is drinking age.`
+  throw new Error(`${name} is not drinking age.`)
+}
+
+/**
+ * @test #integer(1, 10000) ** 2 returns true
+ * @test #constantFrom(3, 5, 8, 13, 21, 1997) returns false
+ */
+export function isSquare (num) {
+  return Math.sqrt(num) % 1 === 0
+}

--- a/test/math.js
+++ b/test/math.js
@@ -1,12 +1,7 @@
 /**
- * @test 1, 2
- * @test '4', 3 throws
- * @test 1, '0' throws
- * @test -1, 1
- * @test -1, 1 to 0
- * @test -1, 1 to -1
- * @test -1, -1 to -2
- * @test -1, '-1' to -2
+ * @test #integer, #integer returns @ as number
+ * @test #integer, #string throws
+ * @test #string, #integer throws
  * @param {number} a
  * @param {number} b
  */
@@ -46,8 +41,6 @@ export const fib = n => n <= 2 ? 1 : fib(n - 1) + fib(n - 2)
 
 /**
  * @test 1, 3 resolves @ as number
- * @test 1, 5 resolves @ as string
- * @test 1, 5 resolves 7
  * @test 5n, 3n
  * @param {number} a
  * @param {number} b

--- a/test/password_module.js
+++ b/test/password_module.js
@@ -201,26 +201,12 @@ export function not (rule, error) {
  * @test 'Hello, $0' ~> 'World' returns 'Hello, World'
  * @test '$0, $1' ~> 'Hello', 'World' returns 'Hello, World'
  * @test 'Hey $0' ~> 'Steve' returns 'Hey Steve'
+ * @test "Attempt: $0" ~> #string returns cat("Attempt: ", args.0)
+ * @test "Attempt: $0 $1" ~> #string, #string returns cat('Attempt: ', args.0, ' ', args.1)
  *
  * @param {string} stringTemplate
  * @returns {(...args: string[]) => string}
  */
 export function template (stringTemplate) {
-  // Simple optimization for the single argument case.
-  if (!/\$[1-9]/.test(stringTemplate)) {
-    /** @param {string} str */
-    return str => stringTemplate.replace(/\$0/g, str)
-  }
-
-  /**
-   * Replaces parts of the string with the arguments.
-   * @param {string[]} args
-   */
-  return (...args) => {
-    let template = stringTemplate
-    for (let i = 0; i < args.length; i++) {
-      template = template.replace(new RegExp(`\\$${i}`, 'g'), args[i])
-    }
-    return template
-  }
+  return (...args) => stringTemplate.replace(/\$[0-9]/g, match => args[+match[1]])
 }

--- a/utils.js
+++ b/utils.js
@@ -1,6 +1,9 @@
 import chalk from 'chalk'
 import { diff as jestDiff } from 'jest-diff'
+import engine from './methods.js'
 import { serialize } from './snapshot.js'
+import fc from 'fast-check'
+import { ConstantFunc } from './symbols.js'
 
 /**
  * It takes the output of the diff function and if it contains the string "Comparing two different
@@ -15,4 +18,166 @@ export function diff (expected, received) {
     return `${result}\n  ${chalk.green(`- Expected: ${serialize(expected).replace(/\n/g, '\n  ')}`)}\n${chalk.red(`  - Received: ${serialize(received).replace(/\n/g, '\n  ')}`)}`
   }
   return result
+}
+
+const tupleConstApplication = item => {
+  if (item && typeof item === 'object') {
+    const key = Object.keys(item)[0]
+    if (key.startsWith('#')) {
+      return item
+    }
+  }
+  return { '#constant': item }
+}
+
+// TODO: add better touch up for [1, 2, #integer],
+// so that if in a tuple or obj, it'll go ahead and make the remaining values #constant wrapped :)
+
+/**
+ * Used to touch up the logic so that statements that aren't completely valid with arbitraries are made valid,
+ * like #record({ id: #integer }) and { id: #integer } become the same.
+ * @param {*} item
+ * @returns
+ */
+function touchUpArbitrary (item) {
+  if (!item) return item
+  if (typeof item === 'number') return item
+  if (typeof item === 'string') return item
+  if (typeof item === 'boolean') return item
+  if (typeof item === 'bigint') return item
+
+  const key = Object.keys(item)[0]
+
+  if (key.startsWith('#')) {
+    if (item[key] && item[key].obj) {
+      return {
+        [key]: {
+          obj: item[key].obj.map(touchUpArbitrary)
+        }
+      }
+    }
+
+    if (item[key] && item[key].list) {
+      return {
+        [key]: {
+          list: item[key].list.map(touchUpArbitrary)
+        }
+      }
+    }
+  }
+
+  if (key === 'obj') {
+    if (item[key].some(i => (Object.keys(i || {})[0] || '').startsWith('#'))) {
+      return {
+        '#record': {
+          obj: item[key]
+            .map(touchUpArbitrary)
+            // apply a fix to the values of the obj so that they're all wrapped in #constant,
+            // this makes the sugar simpler.
+            .map((i, x) => (x & 1) ? tupleConstApplication(i) : i)
+        }
+      }
+    }
+  }
+
+  if (key === 'list') {
+    if (item[key].some(i => (Object.keys(i || {})[0] || '').startsWith('#'))) {
+      return {
+        '#tuple': {
+          list: item[key]
+            .map(touchUpArbitrary)
+            // makes the sugar simpler by applying #constant to the constant values of an inferred tuple.
+            .map(tupleConstApplication)
+        }
+      }
+    }
+  }
+
+  const count = arbitraryBranchCount(item)
+
+  if (count === 0) {
+    return item
+  } else if (count === 1) {
+    const [map, arbitraries] = traverseSubstitute(item)
+    return {
+      ...arbitraries[0],
+      map
+    }
+  } else throw new Error('You may not use more than one arbitrary in an argument, did you intend to use #record or #tuple?')
+}
+
+/**
+ * Count the number of references to arbitraries in the logic tree.
+ * (Nested Arbitraries still count as one, because it terminates the traversal
+ * when it reaches one; this is by design!).
+ * @param {*} obj
+ */
+function arbitraryBranchCount (obj) {
+  if (obj && typeof obj === 'object' && !Array.isArray(obj)) {
+    const key = Object.keys(obj)[0]
+    if (key.startsWith('#')) return 1
+
+    if (!Array.isArray(obj[key])) return 0
+
+    return obj[key].reduce((acc, i) => {
+      acc += arbitraryBranchCount(i)
+      return acc
+    }, 0)
+  }
+  return 0
+}
+
+const basicSub = { var: '' }
+
+/**
+ * Substitute any arbitraries with a "var" expression so that we can perform a map operation
+ * after building the relevant logic. :)
+ * @param {*} obj
+ * @param {*} sub
+ */
+export function traverseSubstitute (obj, sub = []) {
+  if (obj && typeof obj === 'object' && !Array.isArray(obj)) {
+    const key = Object.keys(obj)[0]
+    if (key.startsWith('#')) {
+      sub.push(obj)
+      return [basicSub, sub]
+    }
+
+    return [{
+      [key]: Array.isArray(obj[key]) ? obj[key].map(i => traverseSubstitute(i, sub)[0]) : traverseSubstitute(obj[key], sub)[0]
+    }, sub]
+  }
+  return [obj, sub]
+}
+
+/**
+ * Convert the arguments for a test case into arbitraries.
+ * @param  {...any} args
+ */
+export async function argumentsToArbitraries (...args) {
+  args = args.map(touchUpArbitrary)
+
+  let constant = true
+  const list = []
+  for (const i of args) {
+    if (i && typeof i === 'object') {
+      const keys = Object.keys(i)
+
+      if (keys[0].startsWith('#')) {
+        if (keys[0] !== '#constant' && !engine.methods[keys[0]].method[ConstantFunc]) constant = false
+        const result = await (await engine.build(i))()
+        if (keys[1] === 'map' && i.map !== basicSub) {
+          list.push(result.map(engine.fallback.build(i.map)))
+          continue
+        }
+        list.push(result)
+        continue
+      }
+    }
+
+    list.push(fc.constant(await (await engine.build(i))()))
+  }
+
+  list.constant = constant
+  return list
 }

--- a/website/blog/v0.9.0.md
+++ b/website/blog/v0.9.0.md
@@ -1,0 +1,94 @@
+---
+tags: [v0.9.0, patch, fast-check]
+sidebar_position: 4
+date: 2022-05-22
+authors: 
+    - name: Jesse Mitchell
+      title: Developer of Pineapple
+      url: https://github.com/TotalTechGeek
+      image_url: https://github.com/TotalTechGeek.png
+---
+
+# Supercharging Pineapple with Property Based Testing (v0.9.0)
+
+Hi all!
+
+This release is focused on introducing fuzzing / property based testing to the Pineapple framework, which should make it ridiculously easy to cover a variety of test cases with simple test expressions.
+
+Utilizing the amazing [fast-check](https://github.com/dubzzz/fast-check) npm package, Pineapple is now able to fuzz a handful of test-cases and shrink any counter-examples down to the smallest test-case it can find to trip an error.
+
+For example:
+
+```js
+
+/**
+ * Using fuzz testing, this will cover a handful of scenarios,
+ * positives, negatives, zeroes
+ * Without you needing to go over each example explicitly.
+ * 
+ * @test #integer, #integer returns @ as number
+ * @test #integer, #integer returns args.0 + args.1
+ * 
+ * The above test is a little silly since it's embedding the   
+ * same logic in the test, but demonstrates that it's possible.
+ */
+function add (a, b) {
+    return a + b 
+}
+
+/**
+ * @test #array(#integer) returns @ as number
+ * @test #array(#string, { minLength: 1 }) throws
+ * @test [1, 2, 3] returns 6
+ * @test [#integer, 2, 3] returns args.0.0 + 5
+ * @test [] returns 0
+ */
+export function sum (values) {
+  if (values.some(i => typeof i !== 'number')) throw new Error('An item in the array is not a number.')
+  return values.reduce((a, b) => a + b, 0)
+}
+
+/**
+ * @test { name: #string, age: #integer(1, 20) } throws
+ * @test { name: 'Jesse', age: #integer(21, 80) } returns cat(args.0.name, ' is drinking age.')
+ */
+export function drinkingAge ({ name, age }) {
+  if (age >= 21) return `${name} is drinking age.`
+  throw new Error(`${name} is not drinking age.`)
+}
+```
+
+This works great for handling a variety of scenarios without having to write much code, and also works with the snapshot tech built into Pineapple (making it even easier to pin functionality for a handful of test-cases).
+
+When your tests fail though, Pineapple & Fast-Check will work together to help identify the issue.
+
+```js
+/**
+ * A simple template function.
+ * @test 'Hello $0' ~> #string returns cat('Hello ', args.0)
+ * @param {string} templateString
+ */
+export function template (templateString) {
+  /** @param {string} replace */
+  return replace => templateString.replace(/\$0/g, replace)
+}
+```
+
+```
+✖ Failed test (template): 'Hello $0' ~> #string returns cat('Hello ', args.0)
+>> file:///Users/jesse/Documents/Projects/pineapple/test/fuzz.js:35
+- Expected
++ Received
+
+- Hello $$
++ Hello $
+Failing Example: [
+  "$$"
+]
+Shrunk 4 times.
+Seed: -2121637705
+```
+
+Fast-Check shrinks the test-case to help you as the developer realize: "Oh! The replace string needs escaped because the `$` character is special in the replace function."
+
+If you wish to read up more on the Fuzz Testing technology, [you may do so here](/docs/writing-tests/fuzzing-property-based).

--- a/website/docs/writing-tests/fuzzing-property-based.md
+++ b/website/docs/writing-tests/fuzzing-property-based.md
@@ -1,0 +1,117 @@
+---
+sidebar_position: 3
+---
+
+# Fuzz Testing
+
+## General Use
+
+Leveraging the technology from the amazing [fast-check](https://github.com/dubzzz/fast-check) npm package, Pineapple enables you to write rather comprehensive tests in a small, single statements.
+
+```js
+/**
+ * Adds two numbers together
+ * @test #integer, #integer returns @ as number
+ * @test #integer, #string throws
+ * @test #string, #integer throws
+ * @param {number} a
+ * @param {number} b
+ */
+export function add (a, b) {
+  if (typeof a !== 'number' || typeof b !== 'number') throw new Error('Not numbers')
+  return a + b
+}
+```
+
+By using a `#arbitrary` tag, you're able to describe what information should be tested, Pineapple + Fast-Check will try a handful of test cases against your function and try to find any counter-examples where your condition fails.
+
+This technology also works with snapshots.
+
+You may also invoke the `#arbitrary` tags with arguments, as if it were a function call, and construct objects / tuples from them. You may also use `args` to refer to the arguments that were used to call the function, which is particularly useful for fuzzed-test cases.
+
+```js
+/*
+ * @test { name: #string, age: #integer(1, 20) } throws
+ * @test { name: #string, age: #integer(21, 80) } returns cat(args.0.name, ' is drinking age.')
+ */
+export function drinkingAge ({ name, age }) {
+  if (age >= 21) return `${name} is drinking age.`
+  throw new Error(`${name} is not drinking age.`)
+}
+```
+
+If a counter-example is found, `fast-check` will use a shrinking algorithm to find the smallest possible test-case to trigger the error, for example, if you wrote a sum function like so:
+
+```js
+/**
+ * A simple template function.
+ * @test 'Hello $0' ~> #string returns cat('Hello ', args.0)
+ * @param {string} templateString
+ */
+export function template (templateString) {
+  /** @param {string} replace */
+  return replace => templateString.replace(/\$0/g, replace)
+}
+```
+
+It would generate the following:
+
+```
+✖ Failed test (template): 'Hello $0' ~> #string returns cat('Hello ', args.0)
+>> file:///Users/jesse/Documents/Projects/pineapple/test/fuzz.js:35
+- Expected
++ Received
+
+- Hello $$
++ Hello $
+Failing Example: [
+  "$$"
+]
+Shrunk 4 times.
+Seed: -2121637705
+```
+
+Which should help isolate the nature of the issue (in this case, "$" is special in the replace function, therefore it needs to be escaped with another dollar sign). In this case, the shrinking helps deduce the nature of the issue & reproduce it easily.
+
+You may see a list of [all built-in arbitraries here](https://github.com/dubzzz/fast-check/blob/main/documentation/Arbitraries.md).
+
+## Applying Operations to an Arbitrary
+
+In some cases, you may wish to apply operations to the fuzzed value, Pineapple will parse & handle this use case.
+
+```js
+/**
+ * @test #integer(1, 10000) ** 2 returns true
+ */
+export function isSquare (num) {
+  return Math.sqrt(num) % 1 === 0
+}
+```
+
+## Adding new Arbitraries
+
+If you wish to generate complex data structures, or need to introduce a new type of data-set to fuzz against, you are able to do so by implementing a new arbitrary type, and returning it from a function tagged with `pineapple_define`.
+
+You may read up on how to implement them [under fast-check's documentation](https://github.com/dubzzz/fast-check/blob/main/documentation/AdvancedArbitraries.md).
+
+```js
+import fc from 'fast-check' 
+
+/**
+ * @pineapple_define
+ */
+function arbitraries () {
+    return {
+        // you can pass in an arbitrary, a function that returns an arbitrary, or a value that'll be constant.
+        // it will be named the value that you define here in the Pineapple engine.
+        person: fc.record({ id: fc.integer(), name: fc.string(), age: fc.integer(12, 80) }) 
+    }
+}
+
+/**
+ * @test #person returns args.0.age > 21
+ */
+function ofAge (person) {
+    return person.age > 21
+}
+```

--- a/yarn.lock
+++ b/yarn.lock
@@ -914,6 +914,13 @@ external-editor@^3.0.3:
     iconv-lite "^0.4.24"
     tmp "^0.0.33"
 
+fast-check@^2.25.0:
+  version "2.25.0"
+  resolved "https://registry.yarnpkg.com/fast-check/-/fast-check-2.25.0.tgz#5146601851bf3be0953bd17eb2b7d547936c6561"
+  integrity sha512-wRUT2KD2lAmT75WNIJIHECawoUUMHM0I5jrlLXGtGeqmPL8jl/EldUDjY1VCp6fDY8yflyfUeIOsOBrIbIiArg==
+  dependencies:
+    pure-rand "^5.0.1"
+
 fast-deep-equal@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -1983,6 +1990,11 @@ punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+pure-rand@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-5.0.1.tgz#97a287b4b4960b2a3448c0932bf28f2405cac51d"
+  integrity sha512-ksWccjmXOHU2gJBnH0cK1lSYdvSZ0zLoCMSz/nTGh6hDvCSgcRxDyIcOBD6KNxFz3xhMPm/T267Tbe2JRymKEQ==
 
 queue-microtask@^1.2.2:
   version "1.2.3"


### PR DESCRIPTION
# Supercharging Pineapple with Property Based Testing (v0.9.0)

Hi all!

This release is focused on introducing fuzzing / property based testing to the Pineapple framework, which should make it ridiculously easy to cover a variety of test cases with simple test expressions.

Utilizing the amazing [fast-check](https://github.com/dubzzz/fast-check) npm package, Pineapple is now able to fuzz a handful of test-cases and shrink any counter-examples down to the smallest test-case it can find to trip an error.

For example:

```js

/**
 * Using fuzz testing, this will cover a handful of scenarios,
 * positives, negatives, zeroes
 * Without you needing to go over each example explicitly.
 * 
 * @test #integer, #integer returns @ as number
 * @test #integer, #integer returns args.0 + args.1
 * 
 * The above test is a little silly since it's embedding the   
 * same logic in the test, but demonstrates that it's possible.
 */
function add (a, b) {
    return a + b 
}

/**
 * @test #array(#integer) returns @ as number
 * @test #array(#string, { minLength: 1 }) throws
 * @test [1, 2, 3] returns 6
 * @test [#integer, 2, 3] returns args.0.0 + 5
 * @test [] returns 0
 */
export function sum (values) {
  if (values.some(i => typeof i !== 'number')) throw new Error('An item in the array is not a number.')
  return values.reduce((a, b) => a + b, 0)
}

/**
 * @test { name: #string, age: #integer(1, 20) } throws
 * @test { name: 'Jesse', age: #integer(21, 80) } returns cat(args.0.name, ' is drinking age.')
 */
export function drinkingAge ({ name, age }) {
  if (age >= 21) return `${name} is drinking age.`
  throw new Error(`${name} is not drinking age.`)
}
```

This works great for handling a variety of scenarios without having to write much code, and also works with the snapshot tech built into Pineapple (making it even easier to pin functionality for a handful of test-cases).

When your tests fail though, Pineapple & Fast-Check will work together to help identify the issue.

```js
/**
 * A simple template function.
 * @test 'Hello $0' ~> #string returns cat('Hello ', args.0)
 * @param {string} templateString
 */
export function template (templateString) {
  /** @param {string} replace */
  return replace => templateString.replace(/\$0/g, replace)
}
```

```
✖ Failed test (template): 'Hello $0' ~> #string returns cat('Hello ', args.0)
>> file:///Users/jesse/Documents/Projects/pineapple/test/fuzz.js:35
- Expected
+ Received

- Hello $$
+ Hello $
Failing Example: [
  "$$"
]
Shrunk 4 times.
Seed: -2121637705
```

Fast-Check shrinks the test-case to help you as the developer realize: "Oh! The replace string needs escaped because the `$` character is special in the replace function."
