### PR TITLE
Attempt to remove TS Morph

### DIFF
--- a/basic-parser.js
+++ b/basic-parser.js
@@ -1,0 +1,305 @@
+import { parse } from './parser/dsl.js'
+import { readFileSync } from 'fs'
+
+/**
+ * @pineapple_define
+ */
+export function InternalTests () {
+  return {
+    voidTest: `
+          /** 
+           * @test void
+           */
+          `,
+    addTest: `
+          /**
+           * @test 1, 
+           * 2 returns 3
+           */
+          export function add (a, b) {
+              return a + b
+          }
+      `,
+    moduleExports: `
+          module.exports = { 
+              "hello": age, name 
+          }
+      `,
+    typicalExport: `
+          export { X, Y as Z }
+    `,
+    this: readFileSync('./basic-parser.js').toString(),
+    mathCjs: readFileSync('./test/math.cjs').toString()
+  }
+}
+
+/**
+ * @test "function a () { function b () {} return b }"
+ * @test 'function a () { function b () {} return b } function b () { }'
+ * @test 'z + { { a } + } { b } + c'
+ * @test #this
+ * @param {string} code
+ */
+export function strip (code) {
+  const codeStripped = code.replace(/=\s+\//g, '= //')
+  let count = 0
+  let res = ''
+  let quoteMode = null
+  let commentMode = null
+  for (let i = 0; i < codeStripped.length; i++) {
+    if (!quoteMode && commentMode === 2 && codeStripped[i] === '\n') commentMode = false
+
+    if (!quoteMode && commentMode === 1 && codeStripped[i] === '*' && codeStripped[i + 1] === '/') {
+      commentMode = false
+      i++
+      continue
+    }
+
+    if (commentMode) continue
+
+    if (!quoteMode && codeStripped[i] === '/' && codeStripped[i + 1] === '*') commentMode = 1
+    if (!quoteMode && codeStripped[i] === '/' && codeStripped[i + 1] === '/') commentMode = 2
+
+    if (codeStripped[i] === '"') {
+      if (quoteMode === '"') {
+        quoteMode = null
+        continue
+      } else if (!quoteMode) quoteMode = '"'
+    }
+
+    if (codeStripped[i] === "'") {
+      if (quoteMode === "'") {
+        quoteMode = null
+        continue
+      } else if (!quoteMode) quoteMode = "'"
+    }
+
+    if (codeStripped[i] === '`') {
+      if (quoteMode === '`') {
+        quoteMode = null
+        continue
+      } else if (!quoteMode) quoteMode = '`'
+    }
+    if (quoteMode) continue
+
+    if (codeStripped[i] === '{') count++
+    else if (codeStripped[i] === '}') {
+      if (count > 0) count--
+    } else if (!count) {
+      res += codeStripped[i]
+    }
+  }
+
+  return res
+}
+
+function matchExpr (stripped, types = 'function') {
+  const regex = new RegExp(`(export\\s+)?(async\\s+)?(${types.join('|')})\\s+([A-Za-z0-9_]+)`, 'mg')
+  return [...(stripped.matchAll(regex))].map(i => ({
+    /** @type {string}  */ name: i[4],
+    /** @type {boolean} */ exported: Boolean(i[1]),
+    /** @type {string}  */ type: i[3],
+    /** @type {string}  */ raw: i[0]
+  }))
+}
+
+/**
+ * @test 'export const a = () => b + c; const b = 3'
+ * @test 'class A {}'
+ * @test 'export class A {} class B {}'
+ * @test 'module.exports = {}'
+ * @param {string} code
+ */
+export function getOuterDeclarations (code) {
+  const stripped = strip(code)
+  return matchExpr(stripped, ['class', 'function', 'let', 'const', 'var'])
+}
+
+/**
+ * @test "export function y () { function b () {} return b } const b = 1 + 2"
+ * @test cat(#voidTest, 'function a() {}')
+ * @test #addTest
+ * @test #mathCjs
+ * @param {string} code
+ */
+export function parseCode (code) {
+  const fileLines = code.split('\n')
+
+  // first, get the outer declarations (things that can be tested by Pineapple)
+  const declarations = getOuterDeclarations(code).map(i => {
+    // next append line numbers & indexes
+    const result = {
+      ...i,
+      index: code.indexOf(i.raw),
+      lineNo: 0
+    }
+
+    // this is stupidly inefficient. I'm writing it in a stupid way so
+    // it can be replaced by something intelligent later
+    result.lineNo = code.substring(0, result.index).split('\n').length
+
+    return result
+  })
+
+  // next, get all of the external exports (module.exports =) and (export { })
+  const exports = getExports(code)
+
+  // figure out which ones have tests
+  const result = declarations.map(i => {
+    const step1 = {
+      ...i,
+      tags: getTags(fileLines, i.lineNo - 2)
+    }
+
+    // if (!step1.tags.length) return null
+
+    if (!i.exported) {
+      if (exports[i.name]) {
+        return {
+          ...step1,
+          originalName: i.name,
+          name: exports[i.name],
+          exported: true
+        }
+      }
+    }
+
+    return step1
+  }).filter(i => i)
+
+  return result
+}
+
+/**
+ * Tries to parse tags from a multi-line jsdoc comment block.
+ * You need to specify where the end of the comment block is so that it can crawl up.
+ *
+ * @param {string[]} fileText
+ * @param {number} end
+ * @param {number[] | null} onlyLines
+ */
+function getTags (fileText, end, onlyLines = null, tagTypes = TAG_TYPES) {
+  const tags = []
+
+  if (end < 0) return []
+  // check if previous line has a comment ender
+  if (fileText[end].includes('*/') && !fileText[end].includes('/*')) {
+    // crawl up until you see comment begin
+    while (end > 0) {
+      end--
+      if (onlyLines && !onlyLines.includes(end + 1)) continue
+      if (fileText[end].includes('/*') && !fileText[end].includes('*/')) break
+      for (const type of tagTypes) {
+        if (new RegExp(`@${type}($| )`).test(fileText[end])) {
+          tags.unshift({
+            type,
+            text: multiLine(fileText, end, type),
+            lineNo: end + 1
+          })
+        }
+      }
+    }
+  }
+
+  return tags
+}
+
+const TAG_TYPES = [
+  'test',
+  'test_static',
+  'pineapple_import',
+  'pineapple_define',
+  'beforeAll',
+  'afterAll',
+  'before',
+  'after',
+  'beforeEach',
+  'afterEach',
+  'beforeGlobal',
+  'beforeEachGlobal',
+  'afterGlobal',
+  'afterEachGlobal'
+]
+
+/**
+ * An algorithm to try to parse out multi-line tests.
+ * Terminates at either a new tag, or at the end of the comment chain.
+ * It will continue crawling down until it terminates, and a test case is parsed correctly,
+ * it use that instead of just the first line.
+ *
+ * This approach allows us to do multi-line without adding "\" to the end of the lines,
+ * which would be rather ugly.
+ * @param {string[]} fileText
+ * @param {number} start
+ * @param {string} type
+ */
+function multiLine (fileText, start, type) {
+  let end = start + 1
+
+  let text = (fileText[start].split(`@${type} `)[1] || '').trim()
+  let lastSuccess = text
+
+  while (fileText[end] && !fileText[end].includes('* @') && !fileText[end].includes('*/')) {
+    const addition = fileText[end]
+      .substring(fileText[end].indexOf('*') + 1)
+      .trim()
+
+    text += '\n' + addition
+
+    try {
+      // attempt a parse, if it succeeds, flag it as successful & use that.
+      parse(text, {})
+      lastSuccess = text
+    } catch (err) {}
+
+    end++
+  }
+
+  return lastSuccess.trim()
+}
+
+/**
+ * Parses out exports that are not declared on the function,
+ * typical for "exports.X", "module.exports = { X }", "export { X }"
+ *
+ * Right now, this only supports module.exports and export { X }, the others will be crafted soon.
+ *
+ * @test #moduleExports
+ * @test #typicalExport
+ *
+ * @param {string} code
+ */
+export function getExports (code) {
+  const module = /module.exports\s*=\s*{\s*([A-Za-z0-9._$]+,?\s*|'?"?[A-Za-z0-9._$]+'?"?\s*:\s*[A-Za-z0-9._$]+,?\s*)+\s*}/
+
+  const exported = {}
+  const item = code.match(module)
+
+  if (item) {
+    const match = item[0]
+    match.substring(match.indexOf('{') + 1, match.length - 1).trim().split(',').map(i => {
+      const arr = i.split(':').map(i => i.trim().replace(/"|'/g, ''))
+      if (arr.length === 1) return [arr[0], arr[0]]
+      return arr
+    }).forEach(item => {
+      exported[item[1]] = item[0]
+    })
+  }
+
+  const module2 = /export\s*{\s*([A-Za-z0-9._$]+,?\s*|[A-Za-z0-9._$]+\s*as\s*[A-Za-z0-9._$]+,?\s*)+\s*}/
+
+  const item2 = code.match(module2)
+
+  if (item2) {
+    const match = item2[0]
+    match.substring(match.indexOf('{') + 1, match.length - 1).trim().split(',').map(i => {
+      const arr = i.split('as').map(i => i.trim().replace(/"|'/g, ''))
+      if (arr.length === 1) return [arr[0], arr[0]]
+      return arr
+    }).forEach(item => {
+      exported[item[1]] = item[0]
+    })
+  }
+
+  return exported
+}

--- a/basic-parser.js
+++ b/basic-parser.js
@@ -34,7 +34,7 @@ export function InternalTests () {
       exports.Y = Y;
     `,
     quoteIssue: `
-          function a () {
+          function a (x = /helloWorld\\//) {
 
           }
 

--- a/basic-parser.js
+++ b/basic-parser.js
@@ -42,6 +42,7 @@ export function InternalTests () {
  */
 export function strip (code) {
   const codeStripped = code
+    .replace(/as\s+const/g, '')
   // .replace(/=>?\s+\//g, '= //')
   let count = 0
   let res = ''

--- a/basic-parser.js
+++ b/basic-parser.js
@@ -320,7 +320,9 @@ function multiLine (fileText, start, type) {
  * Parses out exports that are not declared on the function,
  * typical for "exports.X", "module.exports = { X }", "export { X }"
  *
- * Right now, this only supports module.exports and export { X }, the others will be crafted soon.
+ * Right now, this only supports module.exports and export { X }, and exports.X = X
+ *
+ * Todo: Default Functions and module.exports = X.
  *
  * @test #Parser.moduleExports
  * @test #Parser.typicalExport

--- a/basic-parser.js.psnap
+++ b/basic-parser.js.psnap
@@ -11,8 +11,20 @@
     "value": "z +   + c",
     "async": false
   },
-  "strip(#this) [4d65eaa2e420fcdffbdf76839b71460df67152127cbfa791967495b4dd2e6b23]": {
+  "strip(#Parser.this) [b2c9b0778c038b4c610f0b7bf33c855e55c7bd420998e5e270a953b68436a856]": {
     "value": "import  from \nimport  from \n\n\nexport function InternalTests () \n\n\nexport function strip (code) \n\nfunction matchExpr (stripped, types = ) \n\n\nexport function getOuterDeclarations (code) \n\n\nexport function parseCode (code) \n\n\nfunction getTags (fileText, end, onlyLines = null, tagTypes = TAG_TYPES) \n\nconst TAG_TYPES = [\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  \n]\n\n\nfunction multiLine (fileText, start, type) \n\n\nexport function getExports (code) \n",
+    "async": false
+  },
+  "strip(#Parser.quoteIssue) [54d9dec5f289594ea462458dfef36c98062bcebcbc20b1ade2ddd558f251c7f1]": {
+    "value": "\n          function a () \n\n          function b () \n\n          function c () \n    ",
+    "async": false
+  },
+  "strip(#Parser.passwordModule) [e827997ef4fd0a0508ab31e4871d05998fc2f0bede859edbbb28cc7cd9e1a044]": {
+    "value": "\n\n\nexport function password (...rules) \n\n\nexport function min (num) \n\n\nexport function max (num) \n\n\nexport function has (charSet, num = 1, name = ) \n\nexport function hasLowerCase (num = 1) \n\n\nexport function hasUpperCase (num = 1) \n\n\nexport function hasSpecial (num = 1) \n\n\nexport function hasDigit (num = 1) \n\n\nexport function includes (requiredText) \n\n\nexport function notIncludes (requiredText, substitute = false) \n\n\nfunction substituteError (substitute, text) \n\n\nexport function some (...rules) \n\n\nexport function not (rule, error) \n\n\nexport function template (stringTemplate) \n",
+    "async": false
+  },
+  "strip(#Parser.setupTest) [3ca9201f21f33d7197508b830d4d56c51671170bb96a74311dc1438a68c192bd]": {
+    "value": "\nexport function isPrime (n) \n\n\nexport function generatePrime () \n\nlet person\n\n\nexport function createPerson (name, level) \n\n\nexport function levelUp (amount) \n\nlet cities = new Set()\n\n\nexport async function initializeCityDatabase () \n\n\nexport async function isCity (city) \n",
     "async": false
   },
   "getOuterDeclarations('export const a = () => b + c; const b = 3') [fbd03bdaf87902765e7ccb156b5e53b1f05013a08369ee241e5a74c87ec4bd28]": {
@@ -21,13 +33,13 @@
         "name": "a",
         "exported": true,
         "type": "const",
-        "raw": "export const a"
+        "raw": "export const a "
       },
       {
         "name": "b",
         "exported": false,
         "type": "const",
-        "raw": "const b"
+        "raw": "const b "
       }
     ],
     "async": false
@@ -38,7 +50,7 @@
         "name": "A",
         "exported": false,
         "type": "class",
-        "raw": "class A"
+        "raw": "class A "
       }
     ],
     "async": false
@@ -49,13 +61,13 @@
         "name": "A",
         "exported": true,
         "type": "class",
-        "raw": "export class A"
+        "raw": "export class A "
       },
       {
         "name": "B",
         "exported": false,
         "type": "class",
-        "raw": "class B"
+        "raw": "class B "
       }
     ],
     "async": false
@@ -71,7 +83,7 @@
         "name": "y",
         "exported": true,
         "type": "function",
-        "raw": "export function y",
+        "raw": "export function y ",
         "index": 0,
         "lineNo": 1,
         "tags": [
@@ -81,7 +93,7 @@
         "name": "b",
         "exported": false,
         "type": "const",
-        "raw": "const b",
+        "raw": "const b ",
         "index": 51,
         "lineNo": 1,
         "tags": [
@@ -90,13 +102,13 @@
     ],
     "async": false
   },
-  "parseCode(cat(#voidTest, 'function a() {}')) [bb3815dc7bdd40532b61549a15723b5ca488ff0282caabdcd4a7dce1657ab15a]": {
+  "parseCode(cat(#Parser.voidTest, 'function a() {}')) [abb8a7487db82a00aee82f4df41d877319ddd1a014d8f8a0641344176148679e]": {
     "value": [
       {
         "name": "a",
         "exported": false,
         "type": "function",
-        "raw": "function a",
+        "raw": "function a(",
         "index": 64,
         "lineNo": 5,
         "tags": [
@@ -110,13 +122,13 @@
     ],
     "async": false
   },
-  "parseCode(#addTest) [56cef2ae76a110c4e7939af7007b8e312c7d11593759333794fa4b50e88b6eed]": {
+  "parseCode(#Parser.addTest) [eb06d1f7401f1f43197450d6ab1093da4de1f0c363a9f8bfc2bd39a08e8e150b]": {
     "value": [
       {
         "name": "add",
         "exported": true,
         "type": "function",
-        "raw": "export function add",
+        "raw": "export function add ",
         "index": 87,
         "lineNo": 6,
         "tags": [
@@ -130,13 +142,13 @@
     ],
     "async": false
   },
-  "parseCode(#mathCjs) [a9c0aca2e167c1cf6a26e2d160b0d381d66d6f602e1f1f1e83463e97fe976f15]": {
+  "parseCode(#Parser.mathCjs) [4fb1aeb1fe3ddbb68fb48f5ef1d00590dfe06fb8075da4367d90e9a1f6e14d6e]": {
     "value": [
       {
         "name": "add",
         "exported": true,
         "type": "function",
-        "raw": "function add",
+        "raw": "function add ",
         "index": 105,
         "lineNo": 8,
         "tags": [
@@ -151,17 +163,649 @@
     ],
     "async": false
   },
-  "getExports(#moduleExports) [022d1b62b065f69d2ed62fbf2fb3b35fe2f41a97703328bff98c0404bf8be141]": {
+  "parseCode(#Parser.passwordModule) [e827997ef4fd0a0508ab31e4871d05998fc2f0bede859edbbb28cc7cd9e1a044]": {
+    "value": [
+      {
+        "name": "password",
+        "exported": true,
+        "type": "function",
+        "raw": "export function password ",
+        "index": 189,
+        "lineNo": 8,
+        "tags": [
+        ]
+      },
+      {
+        "name": "min",
+        "exported": true,
+        "type": "function",
+        "raw": "export function min ",
+        "index": 629,
+        "lineNo": 27,
+        "tags": [
+          {
+            "type": "test",
+            "text": "3 ~> 'hi' returns truthy",
+            "lineNo": 20
+          },
+          {
+            "type": "test",
+            "text": "3 ~> 'hi hi hi' returns undefined",
+            "lineNo": 21
+          }
+        ]
+      },
+      {
+        "name": "max",
+        "exported": true,
+        "type": "function",
+        "raw": "export function max ",
+        "index": 1000,
+        "lineNo": 39,
+        "tags": [
+          {
+            "type": "test",
+            "text": "3 ~> 'hi' returns undefined",
+            "lineNo": 32
+          },
+          {
+            "type": "test",
+            "text": "3 ~> 'hi hi hi' returns truthy",
+            "lineNo": 33
+          }
+        ]
+      },
+      {
+        "name": "has",
+        "exported": true,
+        "type": "function",
+        "raw": "export function has ",
+        "index": 1484,
+        "lineNo": 53,
+        "tags": [
+          {
+            "type": "test",
+            "text": "['ø'], 1 ~> 'Test' returns truthy",
+            "lineNo": 44
+          },
+          {
+            "type": "test",
+            "text": "['ø'], 1 ~> 'Testø' returns undefined",
+            "lineNo": 45
+          }
+        ]
+      },
+      {
+        "name": "hasLowerCase",
+        "exported": true,
+        "type": "function",
+        "raw": "export function hasLowerCase ",
+        "index": 2061,
+        "lineNo": 70,
+        "tags": [
+          {
+            "type": "test",
+            "text": "1 ~> 'HELLO' returns truthy",
+            "lineNo": 63
+          },
+          {
+            "type": "test",
+            "text": "1 ~> 'Hello' returns undefined",
+            "lineNo": 64
+          }
+        ]
+      },
+      {
+        "name": "hasUpperCase",
+        "exported": true,
+        "type": "function",
+        "raw": "export function hasUpperCase ",
+        "index": 2425,
+        "lineNo": 82,
+        "tags": [
+          {
+            "type": "test",
+            "text": "1 ~> 'hello' returns truthy",
+            "lineNo": 75
+          },
+          {
+            "type": "test",
+            "text": "1 ~> 'Hello' returns undefined",
+            "lineNo": 76
+          }
+        ]
+      },
+      {
+        "name": "hasSpecial",
+        "exported": true,
+        "type": "function",
+        "raw": "export function hasSpecial ",
+        "index": 2826,
+        "lineNo": 94,
+        "tags": [
+          {
+            "type": "test",
+            "text": "1 ~> 'Hello' returns truthy",
+            "lineNo": 87
+          },
+          {
+            "type": "test",
+            "text": "1 ~> 'He!lo' returns undefined",
+            "lineNo": 88
+          }
+        ]
+      },
+      {
+        "name": "hasDigit",
+        "exported": true,
+        "type": "function",
+        "raw": "export function hasDigit ",
+        "index": 3179,
+        "lineNo": 106,
+        "tags": [
+          {
+            "type": "test",
+            "text": "1 ~> 'Hello' returns truthy",
+            "lineNo": 99
+          },
+          {
+            "type": "test",
+            "text": "1 ~> 'Hell0' returns undefined",
+            "lineNo": 100
+          }
+        ]
+      },
+      {
+        "name": "includes",
+        "exported": true,
+        "type": "function",
+        "raw": "export function includes ",
+        "index": 3522,
+        "lineNo": 118,
+        "tags": [
+          {
+            "type": "test",
+            "text": "'Hello' ~> 'Hello World' returns undefined",
+            "lineNo": 111
+          },
+          {
+            "type": "test",
+            "text": "'Hello' ~> '' returns truthy",
+            "lineNo": 112
+          }
+        ]
+      },
+      {
+        "name": "notIncludes",
+        "exported": true,
+        "type": "function",
+        "raw": "export function notIncludes ",
+        "index": 4501,
+        "lineNo": 143,
+        "tags": [
+          {
+            "type": "test",
+            "text": "'Kevin' ~> 'Kevin' returns truthy",
+            "lineNo": 130
+          },
+          {
+            "type": "test",
+            "text": "'Kevin' ~> 'Steve' returns undefined",
+            "lineNo": 131
+          },
+          {
+            "type": "test",
+            "text": "'Kevin', false ~> 'Kevin'",
+            "lineNo": 132
+          },
+          {
+            "type": "test",
+            "text": "'Kevin', true ~> 'Kevin'",
+            "lineNo": 133
+          },
+          {
+            "type": "test",
+            "text": "'Kevin', 'This is a message.' ~> 'Kevin'",
+            "lineNo": 134
+          },
+          {
+            "type": "test",
+            "text": "['password01', 'yeet'] ~> 'password01'",
+            "lineNo": 135
+          },
+          {
+            "type": "test",
+            "text": "['password01'] ~> 'yeet'",
+            "lineNo": 136
+          }
+        ]
+      },
+      {
+        "name": "substituteError",
+        "exported": false,
+        "type": "function",
+        "raw": "function substituteError ",
+        "index": 5236,
+        "lineNo": 164,
+        "tags": [
+        ]
+      },
+      {
+        "name": "some",
+        "exported": true,
+        "type": "function",
+        "raw": "export function some ",
+        "index": 5747,
+        "lineNo": 176,
+        "tags": [
+        ]
+      },
+      {
+        "name": "not",
+        "exported": true,
+        "type": "function",
+        "raw": "export function not ",
+        "index": 6367,
+        "lineNo": 191,
+        "tags": [
+        ]
+      },
+      {
+        "name": "template",
+        "exported": true,
+        "type": "function",
+        "raw": "export function template ",
+        "index": 7139,
+        "lineNo": 210,
+        "tags": [
+          {
+            "type": "test",
+            "text": "'Hello, $0' ~> 'World' returns 'Hello, World'",
+            "lineNo": 201
+          },
+          {
+            "type": "test",
+            "text": "'$0, $1' ~> 'Hello', 'World' returns 'Hello, World'",
+            "lineNo": 202
+          },
+          {
+            "type": "test",
+            "text": "'Hey $0' ~> 'Steve' returns 'Hey Steve'",
+            "lineNo": 203
+          },
+          {
+            "type": "test",
+            "text": "\"Attempt: $0\" ~> #string returns cat(\"Attempt: \", args.0)",
+            "lineNo": 204
+          },
+          {
+            "type": "test",
+            "text": "\"Attempt: $0 $1\" ~> #string, #string returns cat('Attempt: ', args.0, ' ', args.1)",
+            "lineNo": 205
+          }
+        ]
+      }
+    ],
+    "async": false
+  },
+  "parseCode(#Parser.setupTest) [3ca9201f21f33d7197508b830d4d56c51671170bb96a74311dc1438a68c192bd]": {
+    "value": [
+      {
+        "name": "isPrime",
+        "exported": true,
+        "type": "function",
+        "raw": "export function isPrime ",
+        "index": 50,
+        "lineNo": 5,
+        "tags": [
+          {
+            "type": "pineapple_import",
+            "text": "",
+            "lineNo": 2
+          }
+        ]
+      },
+      {
+        "name": "generatePrime",
+        "exported": true,
+        "type": "function",
+        "raw": "export function generatePrime ",
+        "index": 235,
+        "lineNo": 17,
+        "tags": [
+          {
+            "type": "test",
+            "text": "void returns isPrime(@)",
+            "lineNo": 15
+          }
+        ]
+      },
+      {
+        "name": "person",
+        "exported": false,
+        "type": "let",
+        "raw": "let person\n",
+        "index": 285,
+        "lineNo": 21,
+        "tags": [
+        ]
+      },
+      {
+        "name": "createPerson",
+        "exported": true,
+        "type": "function",
+        "raw": "export function createPerson ",
+        "index": 384,
+        "lineNo": 27,
+        "tags": [
+          {
+            "type": "pineapple_import",
+            "text": "",
+            "lineNo": 25
+          }
+        ]
+      },
+      {
+        "name": "levelUp",
+        "exported": true,
+        "type": "function",
+        "raw": "export function levelUp ",
+        "index": 644,
+        "lineNo": 40,
+        "tags": [
+          {
+            "type": "beforeEach",
+            "text": "createPerson('John', 5)",
+            "lineNo": 36
+          },
+          {
+            "type": "test",
+            "text": "3 returns @.level === 8",
+            "lineNo": 37
+          },
+          {
+            "type": "test",
+            "text": "1 returns @.level === 6",
+            "lineNo": 38
+          }
+        ]
+      },
+      {
+        "name": "cities",
+        "exported": false,
+        "type": "let",
+        "raw": "let cities ",
+        "index": 723,
+        "lineNo": 45,
+        "tags": [
+        ]
+      },
+      {
+        "name": "initializeCityDatabase",
+        "exported": true,
+        "type": "function",
+        "raw": "export async function initializeCityDatabase ",
+        "index": 769,
+        "lineNo": 50,
+        "tags": [
+          {
+            "type": "beforeAll",
+            "text": "",
+            "lineNo": 48
+          }
+        ]
+      },
+      {
+        "name": "isCity",
+        "exported": true,
+        "type": "function",
+        "raw": "export async function isCity ",
+        "index": 1031,
+        "lineNo": 64,
+        "tags": [
+          {
+            "type": "test",
+            "text": "'Vienna' resolves truthy",
+            "lineNo": 60
+          },
+          {
+            "type": "test",
+            "text": "'San Juan' resolves truthy",
+            "lineNo": 61
+          },
+          {
+            "type": "test",
+            "text": "'United Kingdom' resolves falsy",
+            "lineNo": 62
+          }
+        ]
+      }
+    ],
+    "async": false
+  },
+  "parseCode(#Parser.this) [b2c9b0778c038b4c610f0b7bf33c855e55c7bd420998e5e270a953b68436a856]": {
+    "value": [
+      {
+        "name": "InternalTests",
+        "exported": true,
+        "type": "function",
+        "raw": "export function InternalTests ",
+        "index": 111,
+        "lineNo": 7,
+        "tags": [
+          {
+            "type": "pineapple_define",
+            "text": "Parser",
+            "lineNo": 5
+          }
+        ]
+      },
+      {
+        "name": "strip",
+        "exported": true,
+        "type": "function",
+        "raw": "export function strip ",
+        "index": 1617,
+        "lineNo": 69,
+        "tags": [
+          {
+            "type": "test",
+            "text": "\"function a () { function b () {} return b }\"",
+            "lineNo": 60
+          },
+          {
+            "type": "test",
+            "text": "'function a () { function b () {} return b } function b () { }'",
+            "lineNo": 61
+          },
+          {
+            "type": "test",
+            "text": "'z + { { a } + } { b } + c'",
+            "lineNo": 62
+          },
+          {
+            "type": "test",
+            "text": "#Parser.this",
+            "lineNo": 63
+          },
+          {
+            "type": "test",
+            "text": "#Parser.quoteIssue",
+            "lineNo": 64
+          },
+          {
+            "type": "test",
+            "text": "#Parser.passwordModule",
+            "lineNo": 65
+          },
+          {
+            "type": "test",
+            "text": "#Parser.setupTest",
+            "lineNo": 66
+          }
+        ]
+      },
+      {
+        "name": "matchExpr",
+        "exported": false,
+        "type": "function",
+        "raw": "function matchExpr ",
+        "index": 3853,
+        "lineNo": 151,
+        "tags": [
+        ]
+      },
+      {
+        "name": "getOuterDeclarations",
+        "exported": true,
+        "type": "function",
+        "raw": "export function getOuterDeclarations ",
+        "index": 4421,
+        "lineNo": 168,
+        "tags": [
+          {
+            "type": "test",
+            "text": "'export const a = () => b + c; const b = 3'",
+            "lineNo": 162
+          },
+          {
+            "type": "test",
+            "text": "'class A {}'",
+            "lineNo": 163
+          },
+          {
+            "type": "test",
+            "text": "'export class A {} class B {}'",
+            "lineNo": 164
+          },
+          {
+            "type": "test",
+            "text": "'module.exports = {}'",
+            "lineNo": 165
+          }
+        ]
+      },
+      {
+        "name": "parseCode",
+        "exported": true,
+        "type": "function",
+        "raw": "export function parseCode ",
+        "index": 4867,
+        "lineNo": 183,
+        "tags": [
+          {
+            "type": "test",
+            "text": "\"export function y () { function b () {} return b } const b = 1 + 2\"",
+            "lineNo": 174
+          },
+          {
+            "type": "test",
+            "text": "cat(#Parser.voidTest, 'function a() {}')",
+            "lineNo": 175
+          },
+          {
+            "type": "test",
+            "text": "#Parser.addTest",
+            "lineNo": 176
+          },
+          {
+            "type": "test",
+            "text": "#Parser.mathCjs",
+            "lineNo": 177
+          },
+          {
+            "type": "test",
+            "text": "#Parser.passwordModule",
+            "lineNo": 178
+          },
+          {
+            "type": "test",
+            "text": "#Parser.setupTest",
+            "lineNo": 179
+          },
+          {
+            "type": "test",
+            "text": "#Parser.this",
+            "lineNo": 180
+          }
+        ]
+      },
+      {
+        "name": "getTags",
+        "exported": false,
+        "type": "function",
+        "raw": "function getTags ",
+        "index": 6270,
+        "lineNo": 239,
+        "tags": [
+        ]
+      },
+      {
+        "name": "TAG_TYPES",
+        "exported": false,
+        "type": "const",
+        "raw": "const TAG_TYPES ",
+        "index": 7052,
+        "lineNo": 265,
+        "tags": [
+        ]
+      },
+      {
+        "name": "multiLine",
+        "exported": false,
+        "type": "function",
+        "raw": "function multiLine ",
+        "index": 7779,
+        "lineNo": 294,
+        "tags": [
+        ]
+      },
+      {
+        "name": "getExports",
+        "exported": true,
+        "type": "function",
+        "raw": "export function getExports ",
+        "index": 8718,
+        "lineNo": 331,
+        "tags": [
+          {
+            "type": "test",
+            "text": "#Parser.moduleExports",
+            "lineNo": 325
+          },
+          {
+            "type": "test",
+            "text": "#Parser.typicalExport",
+            "lineNo": 326
+          },
+          {
+            "type": "test",
+            "text": "#Parser.exports",
+            "lineNo": 327
+          }
+        ]
+      }
+    ],
+    "async": false
+  },
+  "getExports(#Parser.moduleExports) [1d6c0c272292a43eec8625d8aaad33fe55cbb3f6a321eb124ab645520e796d63]": {
     "value": {
       "age": "hello",
       "name": "name"
     },
     "async": false
   },
-  "getExports(#typicalExport) [d96782dcba953e96d77f9c88b8ef3937847cde0772853ea17d1edc9171d69a20]": {
+  "getExports(#Parser.typicalExport) [7445ee16714bef86ac4d69a5f8cf5a01f102697be027f1fa62fcd0b9d265fcec]": {
     "value": {
       "X": "X",
-      "Z": "Y"
+      "Z": "Z"
+    },
+    "async": false
+  },
+  "getExports(#Parser.exports) [42e0fa053676204860d6d026c53f7928f6e02ed481389a9e69f4bd97421ee590]": {
+    "value": {
+      "XYZ": "X",
+      "Y": "Y"
     },
     "async": false
   }

--- a/basic-parser.js.psnap
+++ b/basic-parser.js.psnap
@@ -765,23 +765,23 @@
         "exported": true,
         "type": "function",
         "raw": "export function getExports ",
-        "index": 8718,
-        "lineNo": 331,
+        "index": 8757,
+        "lineNo": 333,
         "tags": [
           {
             "type": "test",
             "text": "#Parser.moduleExports",
-            "lineNo": 325
+            "lineNo": 327
           },
           {
             "type": "test",
             "text": "#Parser.typicalExport",
-            "lineNo": 326
+            "lineNo": 328
           },
           {
             "type": "test",
             "text": "#Parser.exports",
-            "lineNo": 327
+            "lineNo": 329
           }
         ]
       }

--- a/basic-parser.js.psnap
+++ b/basic-parser.js.psnap
@@ -1,0 +1,168 @@
+{
+  "strip(\"function a () { function b () {} return b }\") [29ecef3995a697e23749bb7434ba2eff728cdb9a55aede8f39cfa3a635031ff0]": {
+    "value": "function a () ",
+    "async": false
+  },
+  "strip('function a () { function b () {} return b } function b () { }') [d64a6d71a9e36e594b9402598380a36a8b79fdddba53d78e133a67ea40a1fb0b]": {
+    "value": "function a ()  function b () ",
+    "async": false
+  },
+  "strip('z + { { a } + } { b } + c') [eb2a862aea58239a6a00121a631455166c5c76f1ac4ba318fe2dc8e0428b720e]": {
+    "value": "z +   + c",
+    "async": false
+  },
+  "strip(#this) [4d65eaa2e420fcdffbdf76839b71460df67152127cbfa791967495b4dd2e6b23]": {
+    "value": "import  from \nimport  from \n\n/\nexport function InternalTests () \n\n/\nexport function strip (code) \n\nfunction matchExpr (stripped, types = ) \n\n/\nexport function getOuterDeclarations (code) \n\n/\nexport function parseCode (code) \n\n/\nfunction getTags (fileText, end, onlyLines = null, tagTypes = TAG_TYPES) \n\nconst TAG_TYPES = [\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  \n]\n\n/\nfunction multiLine (fileText, start, type) \n\n/\nexport function getExports (code) ",
+    "async": false
+  },
+  "getOuterDeclarations('export const a = () => b + c; const b = 3') [fbd03bdaf87902765e7ccb156b5e53b1f05013a08369ee241e5a74c87ec4bd28]": {
+    "value": [
+      {
+        "name": "a",
+        "exported": true,
+        "type": "const",
+        "raw": "export const a"
+      },
+      {
+        "name": "b",
+        "exported": false,
+        "type": "const",
+        "raw": "const b"
+      }
+    ],
+    "async": false
+  },
+  "getOuterDeclarations('class A {}') [5e3b326fe7fe62b74fae6872b4e91217ee218e3128b95bc58b70ef7a210e9565]": {
+    "value": [
+      {
+        "name": "A",
+        "exported": false,
+        "type": "class",
+        "raw": "class A"
+      }
+    ],
+    "async": false
+  },
+  "getOuterDeclarations('export class A {} class B {}') [dc7995117e68e1ddce6eb6ae86a521f2aaf9df62bb95b47901d9a7427b65cdbf]": {
+    "value": [
+      {
+        "name": "A",
+        "exported": true,
+        "type": "class",
+        "raw": "export class A"
+      },
+      {
+        "name": "B",
+        "exported": false,
+        "type": "class",
+        "raw": "class B"
+      }
+    ],
+    "async": false
+  },
+  "getOuterDeclarations('module.exports = {}') [6b752c2e3185da1f6274ebe57eca4abc5cf3e5b32231fa882600b4d4ef1ffdcb]": {
+    "value": [
+    ],
+    "async": false
+  },
+  "parseCode(\"export function y () { function b () {} return b } const b = 1 + 2\") [bb95771774e8f468a11ec88c59f150456163ef88c968408bbd2e35e9cfc39942]": {
+    "value": [
+      {
+        "name": "y",
+        "exported": true,
+        "type": "function",
+        "raw": "export function y",
+        "index": 0,
+        "lineNo": 1,
+        "tags": [
+        ]
+      },
+      {
+        "name": "b",
+        "exported": false,
+        "type": "const",
+        "raw": "const b",
+        "index": 51,
+        "lineNo": 1,
+        "tags": [
+        ]
+      }
+    ],
+    "async": false
+  },
+  "parseCode(cat(#voidTest, 'function a() {}')) [bb3815dc7bdd40532b61549a15723b5ca488ff0282caabdcd4a7dce1657ab15a]": {
+    "value": [
+      {
+        "name": "a",
+        "exported": false,
+        "type": "function",
+        "raw": "function a",
+        "index": 64,
+        "lineNo": 5,
+        "tags": [
+          {
+            "type": "test",
+            "text": "void",
+            "lineNo": 3
+          }
+        ]
+      }
+    ],
+    "async": false
+  },
+  "parseCode(#addTest) [56cef2ae76a110c4e7939af7007b8e312c7d11593759333794fa4b50e88b6eed]": {
+    "value": [
+      {
+        "name": "add",
+        "exported": true,
+        "type": "function",
+        "raw": "export function add",
+        "index": 87,
+        "lineNo": 6,
+        "tags": [
+          {
+            "type": "test",
+            "text": "1,\n2 returns 3",
+            "lineNo": 3
+          }
+        ]
+      }
+    ],
+    "async": false
+  },
+  "parseCode(#mathCjs) [a9c0aca2e167c1cf6a26e2d160b0d381d66d6f602e1f1f1e83463e97fe976f15]": {
+    "value": [
+      {
+        "name": "add",
+        "exported": true,
+        "type": "function",
+        "raw": "function add",
+        "index": 105,
+        "lineNo": 8,
+        "tags": [
+          {
+            "type": "test",
+            "text": "10, 20 returns 30",
+            "lineNo": 4
+          }
+        ],
+        "originalName": "add"
+      }
+    ],
+    "async": false
+  },
+  "getExports(#moduleExports) [022d1b62b065f69d2ed62fbf2fb3b35fe2f41a97703328bff98c0404bf8be141]": {
+    "value": {
+      "age": "hello",
+      "name": "name"
+    },
+    "async": false
+  },
+  "getExports(#typicalExport) [d96782dcba953e96d77f9c88b8ef3937847cde0772853ea17d1edc9171d69a20]": {
+    "value": {
+      "X": "X",
+      "Z": "Y"
+    },
+    "async": false
+  }
+}

--- a/basic-parser.js.psnap
+++ b/basic-parser.js.psnap
@@ -16,7 +16,7 @@
     "async": false
   },
   "strip(#Parser.quoteIssue) [54d9dec5f289594ea462458dfef36c98062bcebcbc20b1ade2ddd558f251c7f1]": {
-    "value": "\n          function a () \n\n          function b () \n\n          function c () \n    ",
+    "value": "\n          function a (x = ) \n\n          function b () \n\n          function c () \n    ",
     "async": false
   },
   "strip(#Parser.passwordModule) [e827997ef4fd0a0508ab31e4871d05998fc2f0bede859edbbb28cc7cd9e1a044]": {
@@ -605,7 +605,7 @@
         "exported": true,
         "type": "function",
         "raw": "export function strip ",
-        "index": 1617,
+        "index": 1636,
         "lineNo": 69,
         "tags": [
           {
@@ -650,7 +650,7 @@
         "exported": false,
         "type": "function",
         "raw": "function matchExpr ",
-        "index": 3853,
+        "index": 3872,
         "lineNo": 151,
         "tags": [
         ]
@@ -660,7 +660,7 @@
         "exported": true,
         "type": "function",
         "raw": "export function getOuterDeclarations ",
-        "index": 4421,
+        "index": 4440,
         "lineNo": 168,
         "tags": [
           {
@@ -690,7 +690,7 @@
         "exported": true,
         "type": "function",
         "raw": "export function parseCode ",
-        "index": 4867,
+        "index": 4886,
         "lineNo": 183,
         "tags": [
           {
@@ -735,7 +735,7 @@
         "exported": false,
         "type": "function",
         "raw": "function getTags ",
-        "index": 6270,
+        "index": 6289,
         "lineNo": 239,
         "tags": [
         ]
@@ -745,7 +745,7 @@
         "exported": false,
         "type": "const",
         "raw": "const TAG_TYPES ",
-        "index": 7052,
+        "index": 7071,
         "lineNo": 265,
         "tags": [
         ]
@@ -755,7 +755,7 @@
         "exported": false,
         "type": "function",
         "raw": "function multiLine ",
-        "index": 7779,
+        "index": 7798,
         "lineNo": 294,
         "tags": [
         ]
@@ -765,7 +765,7 @@
         "exported": true,
         "type": "function",
         "raw": "export function getExports ",
-        "index": 8757,
+        "index": 8776,
         "lineNo": 333,
         "tags": [
           {

--- a/basic-parser.js.psnap
+++ b/basic-parser.js.psnap
@@ -12,7 +12,7 @@
     "async": false
   },
   "strip(#this) [4d65eaa2e420fcdffbdf76839b71460df67152127cbfa791967495b4dd2e6b23]": {
-    "value": "import  from \nimport  from \n\n/\nexport function InternalTests () \n\n/\nexport function strip (code) \n\nfunction matchExpr (stripped, types = ) \n\n/\nexport function getOuterDeclarations (code) \n\n/\nexport function parseCode (code) \n\n/\nfunction getTags (fileText, end, onlyLines = null, tagTypes = TAG_TYPES) \n\nconst TAG_TYPES = [\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  \n]\n\n/\nfunction multiLine (fileText, start, type) \n\n/\nexport function getExports (code) ",
+    "value": "import  from \nimport  from \n\n\nexport function InternalTests () \n\n\nexport function strip (code) \n\nfunction matchExpr (stripped, types = ) \n\n\nexport function getOuterDeclarations (code) \n\n\nexport function parseCode (code) \n\n\nfunction getTags (fileText, end, onlyLines = null, tagTypes = TAG_TYPES) \n\nconst TAG_TYPES = [\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  \n]\n\n\nfunction multiLine (fileText, start, type) \n\n\nexport function getExports (code) \n",
     "async": false
   },
   "getOuterDeclarations('export const a = () => b + c; const b = 3') [fbd03bdaf87902765e7ccb156b5e53b1f05013a08369ee241e5a74c87ec4bd28]": {

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ const formatOption = new Option('-f, --format <format>', 'The output format').ch
 
 program
   .name('pineapple')
-  .version('0.12.1')
+  .version('0.12.2')
   .option('-i, --include <files...>', 'Comma separated globs of files.')
   .option('-w, --watch-mode', 'Will run tests only when a file is modified.')
   .option('-a, --accept-all', 'Accept all snapshots.')

--- a/index.js
+++ b/index.js
@@ -91,11 +91,11 @@ async function main () {
 
     if (fileChanged.endsWith('.psnap')) return
 
+    console.clear()
     functions = functions.filter(i => i.fileName !== url.pathToFileURL(correctPath).href).concat(
       getFileFunctions(fileChanged)
     )
 
-    console.clear()
     const execFunctions = functions.filter(i => {
       // we also always need to include files with @pineapple_define and global tags.
       const global = i.tags.some(i => i.type === 'pineapple_define' || i.type.includes('Global') || i.type === 'pineapple_import')

--- a/index.js
+++ b/index.js
@@ -95,8 +95,7 @@ async function main () {
       getFileFunctions(fileChanged)
     )
 
-    console.log(fileChanged, functions)
-
+    console.clear()
     const execFunctions = functions.filter(i => {
       // we also always need to include files with @pineapple_define and global tags.
       const global = i.tags.some(i => i.type === 'pineapple_define' || i.type.includes('Global') || i.type === 'pineapple_import')
@@ -291,7 +290,6 @@ function getFunctions (fileText, fileName) {
     isClass: i.type === 'class',
     relativePath: fileName.startsWith(cwd) ? fileName.substring(cwd.length + 1) : ''
   })).filter(i => {
-    console.log(i)
     if (!i.tags || !i.tags.length) return false
     if (!i.exported) skippingTest(i.name, i.fileName, i.tags)
     return i.exported

--- a/methods.js
+++ b/methods.js
@@ -247,6 +247,11 @@ engine.addMethod('rejects', async ([inputs, output], context) => {
   }
 })
 
+engine.addMethod('__fails__', async ([func, inputs, output], context, above, engine) => {
+  const data = await engine.run({ [func.join('')]: [inputs, output] }, context)
+  return [data, !data[1]]
+})
+
 export const createArbitrary = method => data => {
   if (data === undefined) return method()
   return method(...[].concat(data))

--- a/outputs.js
+++ b/outputs.js
@@ -9,6 +9,13 @@ const format = text => text.includes('\n') ? `\n${text}\n` : text
  * @param {string} name
  * @param {string} file
  * @param {{ type: string, text: string, lineNo: number }[]} tags
+ * @test 'ForcedSkip', './outputs.js', [
+ *  { type: 'nonexistent', lineNo: 12, text: 'This is forced.' }
+ * ] returns void
+ * @test 'ForcedSkip2', './outputs.js', [
+ *  { type: 'nonexistent', lineNo: 14, text: 'This is forced in an array.' },
+ *  { type: 'nonexistent', lineNo: 15, text: 'This is forced in an array, too.' }
+ * ] returns void
  */
 export function skippingTest (name, file, tags) {
   if (process.env.OUTPUT_FORMAT === 'CONSOLE') {
@@ -43,6 +50,7 @@ export function success (name, input, file) {
 /**
  * Announces that a test was not successful.
  * @param {{ name: string, input: string, message: string, file: string, data: string }}
+ * @test { name: 'Forced Output', input: 'If this appears, this is successful', file: './outputs.js:46', data: [] } returns void
  */
 export function failure ({ name, input, message, file, data }) {
   if (process.env.OUTPUT_FORMAT === 'CONSOLE') {
@@ -71,6 +79,7 @@ export function failure ({ name, input, message, file, data }) {
  * @param {string} input
  * @param {string} message
  * @param {string} file
+ * @test 'Forced', 'Forced Parse Failure Output', 'Forced Parse Failure Output', './outputs.js' returns void
  */
 export function parseFailure (name, input, message, file) {
   if (process.env.OUTPUT_FORMAT === 'CONSOLE') {
@@ -87,6 +96,7 @@ export function parseFailure (name, input, message, file) {
 /**
  * Tries to log a test runtime error
  * @param {*} err
+ * @test 'Anything' returns void
  */
 export function testRuntimeFailure (err) {
   if (process.env.OUTPUT_FORMAT === 'CONSOLE') {
@@ -117,6 +127,7 @@ export function aggregate (failures, total) {
 /**
  * Print the files that are being tested.
  * @param {string[]} files
+ * @test ['./outputs.js'] returns void
  */
 export function filesTested (files) {
   if (process.env.OUTPUT_FORMAT === 'CONSOLE') {

--- a/outputs.js
+++ b/outputs.js
@@ -8,7 +8,7 @@ const format = text => text.includes('\n') ? `\n${text}\n` : text
  * Announces that a test is being skipped due to it not being exported.
  * @param {string} name
  * @param {string} file
- * @param {{ type: string, text: string, lineNo: number }} tags
+ * @param {{ type: string, text: string, lineNo: number }[]} tags
  */
 export function skippingTest (name, file, tags) {
   if (process.env.OUTPUT_FORMAT === 'CONSOLE') {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "debounce": "^1.2.1",
     "dependency-tree": "^8.1.2",
     "fast-check": "^3.3.0",
+    "glob": "^8.0.3",
     "jest-diff": "^27.5.1",
     "json-logic-engine": "^1.1.21",
     "log-symbols": "^5.1.0",
@@ -33,8 +34,7 @@
     "ramda-adjunct": "^3.0.0",
     "rollup": "^2.70.2",
     "rollup-plugin-require": "^0.0.1",
-    "tempy": "^2.0.0",
-    "ts-morph": "^14.0.0"
+    "tempy": "^2.0.0"
   },
   "devDependencies": {
     "@types/node": "^17.0.25",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pineapple",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "A testing framework for humans.",
   "main": "index.js",
   "scripts": {

--- a/parser/grammar.pegjs
+++ b/parser/grammar.pegjs
@@ -103,7 +103,12 @@
 }
 
 // Documents
-Document = TestExpressionLayered
+Document = 
+    '@__fails__' _req val:TestExpressionLayered { 
+      const key = Object.keys(val[0])[0]
+      return [{ __fails__: [key, ...val[0][key]] }] 
+  }
+  / TestExpressionLayered
 
 TypesParsed = val:Types { return { preserve: toJsonSchema(val) } }
 

--- a/snapshot.js
+++ b/snapshot.js
@@ -41,7 +41,10 @@ export function snapshot (file = './pineapple-snapshot') {
  * @test 5 returns "5"
  * @test true returns "true"
  * @test Infinity returns "Infinity"
- * @test -Infinity returns "-Infinity"
+ *
+ * This next one should be fixed.
+ * @test @__fails__ -Infinity returns "-Infinity"
+ *
  * @test null returns "null"
  * @test undefined returns "undefined"
  * @test void returns "undefined"

--- a/test/fuzz.js
+++ b/test/fuzz.js
@@ -11,8 +11,8 @@ export function sum (values) {
 }
 
 /**
- * @test { name: #string, age: #integer(1, 20) } throws
- * @test { name: 'Jesse', age: #integer(21, 80) } returns cat(args.0.name, ' is drinking age.')
+ * @test { name: #string, age: #integer({ min: 1,  max: 20 }) } throws
+ * @test { name: 'Jesse', age: #integer({ min: 21, max: 80 }) } returns cat(args.0.name, ' is drinking age.')
  */
 export function drinkingAge ({ name, age }) {
   if (age >= 21) return `${name} is drinking age.`

--- a/test/math.cjs
+++ b/test/math.cjs
@@ -1,0 +1,12 @@
+
+/**
+ * A simple CJS add method
+ * @test 10, 20 returns 30
+ * @param {number} a
+ * @param {number} b
+ */
+function add (a, b) {
+  return a + b
+}
+
+module.exports = { add }

--- a/test/rejects.js
+++ b/test/rejects.js
@@ -1,28 +1,28 @@
 
 /**
  * @test 1 rejects 'Annoying error'
- * @test 1 throws 'Annoying error'
+ * @test @__fails__ 1 throws 'Annoying error'
  *
  * @test 2 resolves undefined
- * @test 2 returns undefined
+ * @test @__fails__ 2 returns undefined
  *
- * @test 2 throws
- * @test 2 rejects
+ * @test @__fails__ 2 throws
+ * @test @__fails__ 2 rejects
  */
 export async function throwsAsync (num) {
   if (num === 1) throw new Error('Annoying error')
 }
 
 /**
- * @test 1 ~> 'Hello' returns truthy
- * @test 1 rejects 'Annoying error'
- * @test 1 resolves @.message === 'Annoying Error'
- * @test 1 returns @.message === 'Annoying Error'
+ * @test @__fails__ 1 ~> 'Hello' returns truthy
+ * @test @__fails__ 1 rejects 'Annoying error'
+ * @test @__fails__ 1 resolves @.message === 'Annoying Error'
+ * @test @__fails__ 1 returns @.message === 'Annoying Error'
  * @test 1 throws 'Annoying error'
- * @test 2 resolves undefined
+ * @test @__fails__ 2 resolves undefined
  * @test 2 returns undefined
- * @test 2 throws
- * @test 2 rejects
+ * @test @__fails__ 2 throws
+ * @test @__fails__ 2 rejects
  */
 export function throwsSync (num) {
   if (num === 1) throw new Error('Annoying error')

--- a/yarn.lock
+++ b/yarn.lock
@@ -131,16 +131,6 @@
     estree-walker "^2.0.1"
     picomatch "^2.2.2"
 
-"@ts-morph/common@~0.13.0":
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/@ts-morph/common/-/common-0.13.0.tgz#77dea1565baaf002d1bc2c20e05d1fb3349008a9"
-  integrity sha512-fEJ6j7Cu8yiWjA4UmybOBH9Efgb/64ZTWuvCF4KysGu4xz8ettfyaqFt8WZ1btCxXsGZJjZ2/3svOF6rL+UFdQ==
-  dependencies:
-    fast-glob "^3.2.11"
-    minimatch "^5.0.1"
-    mkdirp "^1.0.4"
-    path-browserify "^1.0.1"
-
 "@types/estree@*":
   version "0.0.51"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.51.tgz#cfd70924a25a3fd32b218e5e420e6897e1ac4f40"
@@ -460,13 +450,6 @@ cliui@^7.0.2:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
-
-code-block-writer@^11.0.0:
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/code-block-writer/-/code-block-writer-11.0.0.tgz#5956fb186617f6740e2c3257757fea79315dd7d4"
-  integrity sha512-GEqWvEWWsOvER+g9keO4ohFoD3ymwyCnqY3hoTr7GZipYFwEhMHJw+TtV0rfgRhNImM6QWZGO2XYjlJVyYT62w==
-  dependencies:
-    tslib "2.3.1"
 
 color-convert@^1.9.0:
   version "1.9.3"
@@ -1054,7 +1037,7 @@ fast-deep-equal@^3.1.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-glob@^3.2.11, fast-glob@^3.2.9:
+fast-glob@^3.2.9:
   version "3.2.11"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
   integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
@@ -1258,6 +1241,17 @@ glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
     minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+glob@^8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-8.0.3.tgz#415c6eb2deed9e502c68fa44a272e6da6eeca42e"
+  integrity sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^5.0.1"
+    once "^1.3.0"
 
 globals@^12.1.0:
   version "12.4.0"
@@ -1804,11 +1798,6 @@ minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
-mkdirp@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
-  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
-
 module-definition@^3.3.1:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/module-definition/-/module-definition-3.4.0.tgz#953a3861f65df5e43e80487df98bb35b70614c2b"
@@ -2048,11 +2037,6 @@ parse-json@^4.0.0:
   dependencies:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
-
-path-browserify@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-1.0.1.tgz#d98454a9c3753d5790860f16f68867b9e46be1fd"
-  integrity sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==
 
 path-exists@^3.0.0:
   version "3.0.0"
@@ -2695,14 +2679,6 @@ ts-interface-checker@^0.1.9:
   resolved "https://registry.yarnpkg.com/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz#784fd3d679722bc103b1b4b8030bcddb5db2a699"
   integrity sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
 
-ts-morph@^14.0.0:
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/ts-morph/-/ts-morph-14.0.0.tgz#6bffb7e4584cf6a9aebce2066bf4258e1d03f9fa"
-  integrity sha512-tO8YQ1dP41fw8GVmeQAdNsD8roZi1JMqB7YwZrqU856DvmG5/710e41q2XauzTYrygH9XmMryaFeLo+kdCziyA==
-  dependencies:
-    "@ts-morph/common" "~0.13.0"
-    code-block-writer "^11.0.0"
-
 ts-toolbelt@^6.15.1:
   version "6.15.5"
   resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz#cb3b43ed725cb63644782c64fbcad7d8f28c0a83"
@@ -2717,11 +2693,6 @@ tsconfig-paths@^3.10.1, tsconfig-paths@^3.11.0, tsconfig-paths@^3.14.1:
     json5 "^1.0.1"
     minimist "^1.2.6"
     strip-bom "^3.0.0"
-
-tslib@2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
-  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tslib@^1.8.1:
   version "1.14.1"


### PR DESCRIPTION
While in the future I may invest in creating yet another grammar (a simplified version of JavaScript that only focuses on the outer scope), 

This PR introduces a really naive parser to get away from the TS-Morph library.

While TS-Morph has served Pineapple well, it is not currently compatible with Bun & introduced more complexity than is really necessary for Pineapple to work. 

This silly parser shaves off a decent amount of time from the test runner & makes watch mode feel more snappy. 