### PR TITLE
Windows Necessary Patches

### DIFF
--- a/basic-parser.js
+++ b/basic-parser.js
@@ -67,6 +67,8 @@ export function InternalTests () {
  * @param {string} code
  */
 export function strip (code) {
+  code = code.replace(/\r\n/g, '\n')
+
   const codeStripped = code
     .replace(/as\s+const/g, '')
   // .replace(/=>?\s+\//g, '= //')
@@ -181,6 +183,7 @@ export function getOuterDeclarations (code) {
  * @param {string} code
  */
 export function parseCode (code) {
+  code = code.replace(/\r\n/g, '\n')
   const fileLines = code.split('\n')
 
   // first, get the outer declarations (things that can be tested by Pineapple)
@@ -331,6 +334,8 @@ function multiLine (fileText, start, type) {
  * @param {string} code
  */
 export function getExports (code) {
+  code = code.replace(/\r\n/g, '\n')
+
   const exported = {}
 
   const module = /module.exports\s*=\s*{\s*([A-Za-z0-9._$]+,?\s*|'?"?[A-Za-z0-9._$]+'?"?\s*:\s*[A-Za-z0-9._$]+,?\s*)+\s*}/

--- a/basic-parser.js.psnap
+++ b/basic-parser.js.psnap
@@ -650,8 +650,8 @@
         "exported": false,
         "type": "function",
         "raw": "function matchExpr ",
-        "index": 3872,
-        "lineNo": 151,
+        "index": 3910,
+        "lineNo": 153,
         "tags": [
         ]
       },
@@ -660,28 +660,28 @@
         "exported": true,
         "type": "function",
         "raw": "export function getOuterDeclarations ",
-        "index": 4440,
-        "lineNo": 168,
+        "index": 4478,
+        "lineNo": 170,
         "tags": [
           {
             "type": "test",
             "text": "'export const a = () => b + c; const b = 3'",
-            "lineNo": 162
-          },
-          {
-            "type": "test",
-            "text": "'class A {}'",
-            "lineNo": 163
-          },
-          {
-            "type": "test",
-            "text": "'export class A {} class B {}'",
             "lineNo": 164
           },
           {
             "type": "test",
-            "text": "'module.exports = {}'",
+            "text": "'class A {}'",
             "lineNo": 165
+          },
+          {
+            "type": "test",
+            "text": "'export class A {} class B {}'",
+            "lineNo": 166
+          },
+          {
+            "type": "test",
+            "text": "'module.exports = {}'",
+            "lineNo": 167
           }
         ]
       },
@@ -690,43 +690,43 @@
         "exported": true,
         "type": "function",
         "raw": "export function parseCode ",
-        "index": 4886,
-        "lineNo": 183,
+        "index": 4924,
+        "lineNo": 185,
         "tags": [
           {
             "type": "test",
             "text": "\"export function y () { function b () {} return b } const b = 1 + 2\"",
-            "lineNo": 174
-          },
-          {
-            "type": "test",
-            "text": "cat(#Parser.voidTest, 'function a() {}')",
-            "lineNo": 175
-          },
-          {
-            "type": "test",
-            "text": "#Parser.addTest",
             "lineNo": 176
           },
           {
             "type": "test",
-            "text": "#Parser.mathCjs",
+            "text": "cat(#Parser.voidTest, 'function a() {}')",
             "lineNo": 177
           },
           {
             "type": "test",
-            "text": "#Parser.passwordModule",
+            "text": "#Parser.addTest",
             "lineNo": 178
           },
           {
             "type": "test",
-            "text": "#Parser.setupTest",
+            "text": "#Parser.mathCjs",
             "lineNo": 179
           },
           {
             "type": "test",
-            "text": "#Parser.this",
+            "text": "#Parser.passwordModule",
             "lineNo": 180
+          },
+          {
+            "type": "test",
+            "text": "#Parser.setupTest",
+            "lineNo": 181
+          },
+          {
+            "type": "test",
+            "text": "#Parser.this",
+            "lineNo": 182
           }
         ]
       },
@@ -735,8 +735,8 @@
         "exported": false,
         "type": "function",
         "raw": "function getTags ",
-        "index": 6289,
-        "lineNo": 239,
+        "index": 6364,
+        "lineNo": 242,
         "tags": [
         ]
       },
@@ -745,8 +745,8 @@
         "exported": false,
         "type": "const",
         "raw": "const TAG_TYPES ",
-        "index": 7071,
-        "lineNo": 265,
+        "index": 7146,
+        "lineNo": 268,
         "tags": [
         ]
       },
@@ -755,8 +755,8 @@
         "exported": false,
         "type": "function",
         "raw": "function multiLine ",
-        "index": 7798,
-        "lineNo": 294,
+        "index": 7873,
+        "lineNo": 297,
         "tags": [
         ]
       },
@@ -765,23 +765,23 @@
         "exported": true,
         "type": "function",
         "raw": "export function getExports ",
-        "index": 8776,
-        "lineNo": 333,
+        "index": 8851,
+        "lineNo": 336,
         "tags": [
           {
             "type": "test",
             "text": "#Parser.moduleExports",
-            "lineNo": 327
+            "lineNo": 330
           },
           {
             "type": "test",
             "text": "#Parser.typicalExport",
-            "lineNo": 328
+            "lineNo": 331
           },
           {
             "type": "test",
             "text": "#Parser.exports",
-            "lineNo": 329
+            "lineNo": 332
           }
         ]
       }

--- a/cli.js
+++ b/cli.js
@@ -23,7 +23,7 @@ const formatOption = new Option('-f, --format <format>', 'The output format').ch
 
 program
   .name('pineapple')
-  .version('0.13.8')
+  .version('0.13.9')
   .option('-i, --include <files...>', 'Comma separated globs of files to include.')
   .option('-e, --exclude <files...>', 'Comma separated globs of files to exclude.')
   .option('-w, --watch-mode', 'Will run tests only when a file is modified.')

--- a/experimental/sequence-arbitrary.js
+++ b/experimental/sequence-arbitrary.js
@@ -1,4 +1,4 @@
-import { generatorToArbitrary } from './generator-to-arbitrary'
+import { generatorToArbitrary } from './generator-to-arbitrary.js'
 
 function * sequence (...arr) {
   for (let i = 0; i < Infinity; i++) {

--- a/experimental/table.js
+++ b/experimental/table.js
@@ -1,5 +1,5 @@
 import fc from 'fast-check'
-import { sequenceArbitrary } from './sequence-arbitrary'
+import { sequenceArbitrary } from './sequence-arbitrary.js'
 
 /**
  * @param {string} str

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pineapple",
-  "version": "0.13.8",
+  "version": "0.13.9",
   "description": "A testing framework for humans.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
# Windows Parser Patches

When I switched parsers, I did not tweak it to remove the `\r\n` from parsing, which on occasion caused subtle differences. This resolves that issue.