### PR TITLE
Add support for regex in scenario testing

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -128,7 +128,8 @@ const getFileFunctions = file => {
     const dependencies = new Set(dependencyTree.toList({
       filename: file,
       directory: '.',
-      filter: str => !str.includes('/node_modules/')
+      filter: str => !str.includes('/node_modules/'),
+      noTypeDefinitions: true
     }))
     // attach the dependencies to the files.
     return functions.map(i => ({ ...i, dependencies }))

--- a/experimental/scenario.d.ts
+++ b/experimental/scenario.d.ts
@@ -18,10 +18,10 @@ export default createNamespace;
  * ```
  * 
  * @param {string | [string]} name The namespace for the steps to avoid collisions
- * @returns {Omit<{ [key: string]: (description: string, func: (...args: any[]) => void) => void }, 'Scenario'> & { Scenario: typeof Scenario }}
+ * @returns {Omit<{ [key: string]: (description: string | RegExp, func: (...args: any[]) => void) => void }, 'Scenario'> & { Scenario: typeof Scenario }}
  */
 declare function createNamespace <T> (name?: string | TemplateStringsArray): Omit<{
-    [key: string]: (description: string, func: (this: T, ...args: any[]) => void) => void;
+    [key: string]: (description: string | RegExp, func: (this: T, ...args: any[]) => void) => void;
 }, "Scenario"> & {
     Scenario: ([script]: TemplateStringsArray) => (...args: any[]) => Promise<{
         ___func___: any;

--- a/experimental/scenario.test.ts
+++ b/experimental/scenario.test.ts
@@ -80,3 +80,12 @@ Then I should have eaten 80 pineapples
  And I have eaten 30 pineapples
  Then I should have eaten 80 pineapples, which is more than {num}
  `
+
+ /**
+  * @test void throws
+  */
+ export const Fails = () => {
+  Given('I have {num} pineapples in my belly', function ({ num }) {
+    this.pineapples = num
+  })
+ }

--- a/experimental/scenario.test.ts
+++ b/experimental/scenario.test.ts
@@ -19,6 +19,22 @@ Then('The number of pineapples should be positive.', function () {
   if (this.pineapples < 0) throw new Error('You cannot have a negative number of pineapples!')
 })
 
+Given(/^I have eaten (\d+) pineapples$/, function (num) {
+  if (!this.pineapples) this.pineapples = 0
+  this.pineapples += +num  
+})
+
+Then(/^I should have eaten (?<count>\d+) pineapples$/, function ({ count }) {
+  if (this.pineapples !== +count) throw new Error('The total number of pineapples is incorrect.')
+})
+
+Then(/^I should have eaten (?<count>\d+) pineapples, which is more than {num}$/, function ({ count }) {
+  return ({ num }) => {
+    if (this.pineapples !== +count) throw new Error('The total number of pineapples is incorrect.')
+    if (this.pineapples < num) throw new Error('The number is less than {num}')
+  }
+})
+
 /**
  * @test { num: 5 } resolves @.pineapples === 4
  * @test { num: #integer({ min: 1 }) } resolves
@@ -45,3 +61,22 @@ export const SecondExample = Scenario`
 export const Unimplemented = Scenario`
 Given I have not implemented a scenario
 Then I should receive a warning telling me what to implement`
+
+
+/**
+ * @test void resolves
+ */
+export const Regex = Scenario`
+Given I have eaten 50 pineapples
+And I have eaten 30 pineapples
+Then I should have eaten 80 pineapples
+`
+
+/**
+ * @test { num: 75 } resolves
+ */
+ export const RegexIntense = Scenario`
+ Given I have eaten 50 pineapples
+ And I have eaten 30 pineapples
+ Then I should have eaten 80 pineapples, which is more than {num}
+ `


### PR DESCRIPTION
# Added Support for Regex Parsing in Scenarios

Because some people may want to parse steps in a fashion more similar to Cucumber, or re-use the same step multiple times in a Scenario (and pass different data in each time), I've begrudgingly added support for regular expressions in the simple scenario framework. 

```javascript
// Use groups to indicate what you want to extract
Given(/^I have eaten (\d+) pineapples$/, function (num) {
  if (!this.pineapples) this.pineapples = 0
  this.pineapples += +num  
})

// named grousp are also supported!
Then(/^I should have eaten (?<count>\d+) pineapples$/, function ({ count }) {
  if (this.pineapples !== +count) throw new Error('The total number of pineapples is incorrect.')
})
```

Rather than passing the scenario arguments into the function, the function will receive the values extracted via regex.

If you do need the values passed into the scenario, you can return an arrow function from the regex step function
```js
Then(/^I should have eaten (?<count>\d+) pineapples, which is more than {num}$/, function ({ count }) {
  return ({ num }) => {
    if (this.pineapples !== +count) throw new Error('The total number of pineapples is incorrect.')
    if (this.pineapples < num) throw new Error('The number is less than {num}')
  }
})
```

I don't foresee this last mechanism being used often, and ideally you'd pull stuff into the `this` context instead, but I wanted to support receiving both sets of values if necessary :P 

So now you can write
```javascript
/**
 * @test void resolves
 */
export const Regex = Scenario`
Given I have eaten 50 pineapples
And I have eaten 30 pineapples
Then I should have eaten 80 pineapples`

// and

/**
 * @test { num: 75 } resolves
 */
 export const RegexIntense = Scenario`
 Given I have eaten 50 pineapples
 And I have eaten 30 pineapples
 Then I should have eaten 80 pineapples, which is more than {num}`
```