### PR TITLE
Timeouts, Configurable Fuzzing, and Better Transpilation

### DIFF
--- a/basic-parser.js
+++ b/basic-parser.js
@@ -270,6 +270,7 @@ const TAG_TYPES = [
   'test_static',
   'pineapple_import',
   'pineapple_define',
+  'pineapple_transpile',
   'beforeAll',
   'afterAll',
   'before',

--- a/basic-parser.js.psnap
+++ b/basic-parser.js.psnap
@@ -12,7 +12,7 @@
     "async": false
   },
   "strip(#Parser.this)": {
-    "value": "import  from \nimport  from \n\n\nexport function InternalTests () \n\n\nexport function strip (code) \n\nfunction matchExpr (stripped, types = ) \n\n\nexport function getOuterDeclarations (code) \n\n\nexport function parseCode (code) \n\n\nfunction getTags (fileText, end, onlyLines = null, tagTypes = TAG_TYPES) \n\nconst TAG_TYPES = [\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  \n]\n\n\nfunction multiLine (fileText, start, type) \n\n\nexport function getExports (code) \n",
+    "value": "import  from \nimport  from \n\n\nexport function InternalTests () \n\n\nexport function strip (code) \n\nfunction matchExpr (stripped, types = ) \n\n\nexport function getOuterDeclarations (code) \n\n\nexport function parseCode (code) \n\n\nfunction getTags (fileText, end, onlyLines = null, tagTypes = TAG_TYPES) \n\nconst TAG_TYPES = [\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  ,\n  \n]\n\n\nfunction multiLine (fileText, start, type) \n\n\nexport function getExports (code) \n",
     "async": false
   },
   "strip(#Parser.quoteIssue)": {
@@ -755,8 +755,8 @@
         "exported": false,
         "type": "function",
         "raw": "function multiLine ",
-        "index": 7873,
-        "lineNo": 297,
+        "index": 7898,
+        "lineNo": 298,
         "tags": [
         ]
       },
@@ -765,23 +765,23 @@
         "exported": true,
         "type": "function",
         "raw": "export function getExports ",
-        "index": 8851,
-        "lineNo": 336,
+        "index": 8876,
+        "lineNo": 337,
         "tags": [
           {
             "type": "test",
             "text": "#Parser.moduleExports",
-            "lineNo": 330
-          },
-          {
-            "type": "test",
-            "text": "#Parser.typicalExport",
             "lineNo": 331
           },
           {
             "type": "test",
-            "text": "#Parser.exports",
+            "text": "#Parser.typicalExport",
             "lineNo": 332
+          },
+          {
+            "type": "test",
+            "text": "#Parser.exports",
+            "lineNo": 333
           }
         ]
       }

--- a/config.test.js
+++ b/config.test.js
@@ -1,0 +1,21 @@
+import fs from 'fs/promises'
+import flowRemoveTypes from 'flow-remove-types'
+
+/**
+ * Transpiles Flow files to JavaScript, the weakness of this implementation is that it doesn't support
+ * bundling, so it doesn't work with other flow files.
+ * Pineapple expects all transpilation functions to export a bundle.
+ * @pineapple_transpile ['*.flow.js']
+ * @param {string} file
+ * @param {string} recommended
+ */
+export async function transpileFlow (file, recommended) {
+  const output = flowRemoveTypes(await fs.readFile(file, { encoding: 'utf-8' }))
+  const map = output.generateMap()
+  map.sources = [file]
+  await fs.writeFile(
+    recommended,
+    `${output.toString()}\n//# sourceMappingURL=data:application/json;base64,${Buffer.from(JSON.stringify(map)).toString('base64')}`
+  )
+  return recommended
+}

--- a/experimental/scenario.test.ts
+++ b/experimental/scenario.test.ts
@@ -39,7 +39,7 @@ Then(/^I should have eaten (?<count>\d+) pineapples, which is more than {num}$/,
  * @test { num: 5 } resolves @.pineapples === 4
  * @test { num: #integer({ min: 1 }) } resolves
  */
-export const Example = Scenario`
+export const Eating = Scenario`
 Given I have {num} pineapples in my belly
 When I vomit one
 Then I should have one less pineapple in my belly
@@ -48,7 +48,7 @@ And The number of pineapples should be positive.`
 /**
  * @test { num: 5 } resolves @.pineapples === 2
  */
-export const SecondExample = Scenario`
+export const MultiVomit = Scenario`
  Given I have {num} pineapples in my belly
  When I vomit one
  And I vomit one
@@ -58,7 +58,7 @@ export const SecondExample = Scenario`
 /**
  * @test @__fails__ void resolves
  */
-export const Unimplemented = Scenario`
+export const UnimplementedScenario = Scenario`
 Given I have not implemented a scenario
 Then I should receive a warning telling me what to implement`
 
@@ -66,11 +66,10 @@ Then I should receive a warning telling me what to implement`
 /**
  * @test void resolves
  */
-export const Regex = Scenario`
+export const RegexScenario = Scenario`
 Given I have eaten 50 pineapples
 And I have eaten 30 pineapples
-Then I should have eaten 80 pineapples
-`
+Then I should have eaten 80 pineapples`
 
 /**
  * @test { num: 75 } resolves
@@ -84,7 +83,7 @@ Then I should have eaten 80 pineapples
  /**
   * @test void throws
   */
- export const Fails = () => {
+ export const FailsDeclaration = () => {
   Given('I have {num} pineapples in my belly', function ({ num }) {
     this.pineapples = num
   })

--- a/outputs.js
+++ b/outputs.js
@@ -39,7 +39,7 @@ export function skippingTest (name, file, tags) {
  */
 export function success (name, input, file) {
   if (process.env.OUTPUT_FORMAT === 'CONSOLE') {
-    console.log(logSymbols.success, `Passed test (${name}):`, format(input))
+    console.log(logSymbols.success, `${chalk.bold.bgGreen(' PASS ')} ${chalk.bold(name)}:`, format(input))
   }
 
   if (process.env.OUTPUT_FORMAT === 'JSON') {
@@ -54,7 +54,7 @@ export function success (name, input, file) {
  */
 export function failure ({ name, input, message, file, data }) {
   if (process.env.OUTPUT_FORMAT === 'CONSOLE') {
-    console.log(logSymbols.error, `Failed test (${name}):`, format(input))
+    console.log(logSymbols.error, `${chalk.bgRed.bold(' FAIL ')} (${name}):`, format(input))
     console.log('>>', file)
     if (message) {
       console.log(message)

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "buildPackage:win32": "rm -rf dist && esbuild index.js --outfile=dist/cjs/index.js --format=cjs --bundle --packages=external && esbuild index.js --outfile=dist/esm/index.js --format=esm --bundle --packages=external && echo { \"type\": \"module\" } > dist/esm/package.json && echo { \"type\": \"commonjs\" } > dist/cjs/package.json && cd dist && exitzero standard --fix */*.js && tsc ../index.js --declaration --allowJs --emitDeclarationOnly --target ESNext --moduleResolution node",
     "buildPackage:default": "rm -rf dist && esbuild index.js --outfile=dist/cjs/index.js --format=cjs --bundle --packages=external && esbuild index.js --outfile=dist/esm/index.js --format=esm --bundle --packages=external && echo '{ \"type\": \"module\" }' > dist/esm/package.json && echo '{ \"type\": \"commonjs\" }' > dist/cjs/package.json && cd dist && exitzero standard --fix */*.js && tsc ../index.js --declaration --allowJs --emitDeclarationOnly --target ESNext --moduleResolution node",
     "generate:parser": "peggy --allowed-start-rules Document,Expression --cache --format es -o parser/dsl.js parser/grammar.pegjs && cd parser && exitzero standard --fix *.js && node patch.js",
-    "test": "c8 --reporter=text --reporter=lcov node cli.js --strict -i \"experimental/*,test/*,*.js\" -t --exclude \"**/*.d.ts\""
+    "test": "c8 --reporter=text --reporter=lcov node cli.js --strict -i \"experimental/*,test/*,*.js\" -t --exclude \"**/*.d.ts\" --fuzz-runs 1000 --timeout 2000"
   },
   "repository": {
     "url": "https://github.com/TotalTechGeek/pineapple",
@@ -45,6 +45,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
     "exitzero": "^1.0.1",
+    "flow-remove-types": "^2.196.3",
     "peggy": "^1.2.0",
     "run-script-os": "^1.1.6",
     "standard": "^16.0.4",

--- a/readme.md
+++ b/readme.md
@@ -56,16 +56,23 @@ Alternatively, you may install the runner globally (add a `-g` flag).
 Usage: pineapple [options]
 
 Options:
-  -V, --version             output the version number
-  -i, --include <files...>  Comma separated globs of files.
-  -a, --accept-all          Accept all snapshots.
-  -u, --update-all          Update all snapshots.
-  -t, --typescript          Enables typescript (slower).
-  --only <lines...>         Allows you to specify which tests you would like to
-                            run.
-  -f, --format <format>     The output format (choices: "json", "console",
-                            default: "console")
-  -h, --help                display help for command
+  -V, --version                  output the version number
+  -i, --include <files...>       Comma separated globs of files to include.
+  -e, --exclude <files...>       Comma separated globs of files to exclude.
+  -w, --watch-mode               Will run tests only when a file is modified.
+  -a, --accept-all               Accept all snapshots.
+  -u, --update-all               Update all snapshots.
+  -t, --transpile                Enables transpilation.
+  --typescript                   Enables transpilation for TypeScript. (legacy flag)
+  --timeout <milliseconds>       The timeout for each test. (default: "5000")
+  --strict                       Enables additional checks to enforce better testing, namely validating that all snapshots are used.
+  --clean                        Cleans up unused snapshots.
+  --only <lines...>              Allows you to specify which tests you would like to run.
+  --fuzz-runs <amount>           The number of runs that fuzz tests perform. (default: "100")
+  --snapshot-fuzz-runs <amount>  The number of runs that fuzz tests perform on a snapshot. (default: "10")
+  -f, --format <format>          The output format (choices: "json", "console", default: "console")
+  --bun                          Uses Bun as the test runner.
+  -h, --help                     display help for command
 ```
 
 #### Example

--- a/test/flow.flow.js
+++ b/test/flow.flow.js
@@ -1,0 +1,19 @@
+// @flow
+
+/**
+ * @test 5, 3
+ */
+export function add (a: number, b: number): number {
+  return a + b
+}
+
+
+/**
+ * @test 5
+ * @test 3
+ * @test void
+ */
+export function toString (value: ?number): string {
+  if (!value) return 'default string'
+  return value.toString()
+} 

--- a/test/flow.flow.js.psnap
+++ b/test/flow.flow.js.psnap
@@ -1,0 +1,18 @@
+{
+  "add(5, 3)": {
+    "value": 8,
+    "async": false
+  },
+  "toString(5)": {
+    "value": "5",
+    "async": false
+  },
+  "toString(3)": {
+    "value": "3",
+    "async": false
+  },
+  "toString(void)": {
+    "value": "default string",
+    "async": false
+  }
+}

--- a/test/math.js
+++ b/test/math.js
@@ -2,6 +2,7 @@
  * @test #number, #number returns @ as number
  * @test #integer, #string throws
  * @test #string, #integer throws
+ * @test #integer, #integer
  * @param {number} a
  * @param {number} b
  */

--- a/test/math.js.psnap
+++ b/test/math.js.psnap
@@ -22,5 +22,85 @@
   "addAsync(5n, 3n)": {
     "value": 8n,
     "async": true
+  },
+  "add(#integer, #integer)": {
+    "value": 1235817845,
+    "async": false,
+    "input": [
+      -233008397,
+      1468826242
+    ]
+  },
+  "add(#integer, #integer).2": {
+    "value": -4019576970,
+    "async": false,
+    "input": [
+      -2147483623,
+      -1872093347
+    ]
+  },
+  "add(#integer, #integer).3": {
+    "value": -2147483673,
+    "async": false,
+    "input": [
+      -2147483648,
+      -25
+    ]
+  },
+  "add(#integer, #integer).4": {
+    "value": -2147483631,
+    "async": false,
+    "input": [
+      -2147483633,
+      2
+    ]
+  },
+  "add(#integer, #integer).5": {
+    "value": -2431079740,
+    "async": false,
+    "input": [
+      -2147483641,
+      -283596099
+    ]
+  },
+  "add(#integer, #integer).6": {
+    "value": -1590925578,
+    "async": false,
+    "input": [
+      -432694778,
+      -1158230800
+    ]
+  },
+  "add(#integer, #integer).7": {
+    "value": 3810924324,
+    "async": false,
+    "input": [
+      1663440700,
+      2147483624
+    ]
+  },
+  "add(#integer, #integer).8": {
+    "value": 4294967271,
+    "async": false,
+    "input": [
+      2147483640,
+      2147483631
+    ]
+  },
+  "add(#integer, #integer).9": {
+    "value": 1195364898,
+    "async": false,
+    "input": [
+      4,
+      1195364894
+    ]
+  },
+  "add(#integer, #integer).10": {
+    "value": 619638713,
+    "async": false,
+    "input": [
+      619638685,
+      28
+    ]
   }
 }

--- a/typescriptTranspiler.js
+++ b/typescriptTranspiler.js
@@ -1,23 +1,17 @@
 
 import url from 'url'
 import path from 'path'
-import { hash } from './hash.js'
-import os from 'os'
 import esbuild from 'esbuild'
-
-const isWin = os.platform() === 'win32'
 
 /**
  * It takes a file path, transpiles it to JavaScript, and returns the file path to the transpiled file
  * @param input - The file to transpile
  * @returns A URL to the transpiled file.
  */
-export async function transpile (input) {
-  const file = `./pineapple-runner/${hash(input)}.mjs`
-
+export async function transpile (input, file) {
   /* Transpiling the file to JavaScript. */
   await esbuild.build({
-    entryPoints: [input.slice('file://'.length + isWin)],
+    entryPoints: [input],
     outfile: file,
     sourcemap: 'inline',
     bundle: true,

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -25,7 +25,7 @@ Pineapple allows you to embed a few example test-cases in your JSDocs, making it
 
 When you omit conditions from your test cases, Pineapple will automatically capture the result of your test & snapshot it, making it easier to preserve expected behavior in your applications, and even easier for users to find examples on how to call your code.
 
-<img alt="An example of the snapshot functionality where the code is modified and the snapshot fails due to a renamed attribute" src="../img/snapshot.gif" width="60%" />
+<img alt="An example of the snapshot functionality where the code is modified and the snapshot fails due to a renamed attribute" src="../img/snapshot.gif" width="80%" />
 
 ## To Install
 
@@ -47,18 +47,23 @@ Alternatively, you may install the runner globally (add a `-g` flag).
 Usage: pineapple [options]
 
 Options:
-  -V, --version             output the version number
-  -i, --include <files...>  Comma separated globs of files.
-  -w, --watch-mode          Will run tests only when a file is modified.
-  -a, --accept-all          Accept all snapshots.
-  -u, --update-all          Update all snapshots.
-  -t, --typescript          Enables typescript (slower).
-  --only <lines...>         Allows you to specify which tests you would like to
-                            run.
-  -f, --format <format>     The output format (choices: "json", "console",
-                            default: "console")
-  --bun                     Uses Bun as the test runner.
-  -h, --help                display help for command
+  -V, --version                  output the version number
+  -i, --include <files...>       Comma separated globs of files to include.
+  -e, --exclude <files...>       Comma separated globs of files to exclude.
+  -w, --watch-mode               Will run tests only when a file is modified.
+  -a, --accept-all               Accept all snapshots.
+  -u, --update-all               Update all snapshots.
+  -t, --transpile                Enables transpilation.
+  --typescript                   Enables transpilation for TypeScript. (legacy flag)
+  --timeout <milliseconds>       The timeout for each test. (default: "5000")
+  --strict                       Enables additional checks to enforce better testing, namely validating that all snapshots are used.
+  --clean                        Cleans up unused snapshots.
+  --only <lines...>              Allows you to specify which tests you would like to run.
+  --fuzz-runs <amount>           The number of runs that fuzz tests perform. (default: "100")
+  --snapshot-fuzz-runs <amount>  The number of runs that fuzz tests perform on a snapshot. (default: "10")
+  -f, --format <format>          The output format (choices: "json", "console", default: "console")
+  --bun                          Uses Bun as the test runner.
+  -h, --help                     display help for command
 
 ```
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1203,6 +1203,20 @@ flatten@^1.0.2:
   resolved "https://registry.npmjs.org/flatten/-/flatten-1.0.3.tgz"
   integrity sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==
 
+flow-parser@^0.196.3:
+  version "0.196.3"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.196.3.tgz#dd923f29a6c194770a4f999f8026ef1da79d428b"
+  integrity sha512-R8wj12eHW6og+IBWeRS6aihkdac1Prh4zw1bfxtt/aeu8r5OFmQEZjnmINcjO/5Q+OKvI4Eg367ygz2SHvtH+w==
+
+flow-remove-types@^2.196.3:
+  version "2.196.3"
+  resolved "https://registry.yarnpkg.com/flow-remove-types/-/flow-remove-types-2.196.3.tgz#665ef6e80bfb656c2e170a848ccb252bbcd248b0"
+  integrity sha512-tunXyUd/jttmYafqPNV0S6+wAIhGbqNhDQHX4UFoJ7Wbwqq6utFQUcAgbn5aHz9RxA5pPI2L3f4R2I6OE8wy2A==
+  dependencies:
+    flow-parser "^0.196.3"
+    pirates "^3.0.2"
+    vlq "^0.2.1"
+
 foreground-child@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz"
@@ -1876,6 +1890,11 @@ natural-compare@^1.4.0:
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
+node-modules-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
+  integrity sha512-JMaRS9L4wSRIR+6PTVEikTrq/lMGEZR43a48ETeilY0Q0iMwVnccMFrUM1k+tNzmYuIU0Vh710bCUqHX+/+ctQ==
+
 node-source-walk@^4.0.0, node-source-walk@^4.2.0, node-source-walk@^4.2.2:
   version "4.3.0"
   resolved "https://registry.npmjs.org/node-source-walk/-/node-source-walk-4.3.0.tgz"
@@ -2124,6 +2143,13 @@ pify@^4.0.1:
   version "4.0.1"
   resolved "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz"
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
+
+pirates@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/pirates/-/pirates-3.0.2.tgz#7e6f85413fd9161ab4e12b539b06010d85954bb9"
+  integrity sha512-c5CgUJq6H2k6MJz72Ak1F5sN9n9wlSlJyEnwvpm9/y3WB4E3pHBDT2c6PEiS1vyJvq2bUxUAIu0EGf8Cx4Ic7Q==
+  dependencies:
+    node-modules-regexp "^1.0.0"
 
 pkg-conf@^3.1.0:
   version "3.1.0"
@@ -2773,6 +2799,11 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+vlq@^0.2.1:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/vlq/-/vlq-0.2.3.tgz#8f3e4328cf63b1540c0d67e1b2778386f8975b26"
+  integrity sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## Timeouts 

While I believe this needs work in the future, I've implemented a flag:
```
--timeout <milliseconds>
```

That will allow you to define the maximum time limit allocated to each test. 

Currently, this encapsulates all iterations of a fuzz test, so if you set `--timeout 5000`, then 5s needs to be enough to finish all the iterations of a fuzz test.

Later on I may add more flexibility and make this multiply. 

## Configuring Number of Runs for PBT / Fuzzing

By using `--fuzz-runs <amount>` `--snapshot-fuzz-runs <amount>`, you can configure how many iterations are performed during a property based test.

## Custom Transpilers

You may now tag a function with `@pineapple_transpile`, which allows you to implement a custom transpile function for a given glob of files.

A simple example is the following: 

```javascript
/**
 * Transpiles Flow files to JavaScript, the weakness of this implementation is that it doesn't support
 * bundling, so it doesn't work with other flow files. It would be better to use the esbuild flow plugin. 
 * Pineapple expects all transpilation functions to export a bundle.
 * @pineapple_transpile ['*.flow.js']
 * @param {string} file
 * @param {string} recommended
 */
export async function transpileFlow (file, recommended) {
  const output = flowRemoveTypes(await fs.readFile(file, { encoding: 'utf-8' }))
  const map = output.generateMap()
  map.sources = [file]
  await fs.writeFile(
    recommended,
    `${output.toString()}\n//# sourceMappingURL=data:application/json;base64,${Buffer.from(JSON.stringify(map)).toString('base64')}`
  )
  return recommended
}
```

You can now chain this to Babel, ESBuild, Rollup, or any other build system to allow you to build and transpile your files for testing.

The function receives two arguments, the first being the file that needs transpiled, and the second being a recommended file to output to. You can ignore the second argument and return any path that you'd like.  

## Prettier Test Output

![image](https://user-images.githubusercontent.com/2261916/211244177-633b62de-84b4-432c-80ff-8fe424503964.png)

This last piece is rather subjective, but I believe the test output is a bit prettier now.