### PR TITLE
Implement enhanced logging feature

### DIFF
--- a/annotation.js
+++ b/annotation.js
@@ -1,0 +1,68 @@
+/* eslint-disable prefer-regex-literals */
+/**
+ * @test 'join(dir, type)'
+ * @test 'path.join(dir, type)'
+ * @test 'const x = path.join(dir, type)'
+ * @test 'const x = path.join(dir, type);'
+ * @test 'path.join(dir,\ntype),'
+ * @param {string} str
+ */
+export function inject (str, func = 'tap(@data)') {
+  // crawl through backwards,
+  let endPosition = str.length - 1
+
+  const punctuation = new Set([' ', '\t', '\n', '\r', ';', ','])
+  while (endPosition >= 0 && punctuation.has(str[endPosition])) endPosition--
+
+  let startPosition = endPosition
+
+  let parenCount = 0
+  let bracketCount = 0
+  let curlyCount = 0
+
+  while (startPosition > 0) {
+    if (str[startPosition] === ')') parenCount++
+    else if (str[startPosition] === '(') parenCount--
+    else if (str[startPosition] === ']') bracketCount++
+    else if (str[startPosition] === '[') bracketCount--
+    else if (str[startPosition] === '}') curlyCount++
+    else if (str[startPosition] === '{') curlyCount--
+    else if (parenCount === 0 && bracketCount === 0 && curlyCount === 0 && str[startPosition] === '=') {
+      startPosition++
+      if (str[startPosition] === '>') startPosition++
+      break
+    } else if (parenCount === 0 && bracketCount === 0 && curlyCount === 0 && (str[startPosition] === '\n' || str[startPosition] === ';' || str[startPosition] === ':' || str[startPosition] === '?')) {
+      startPosition++
+      break
+    }
+
+    if (str.substring(startPosition, endPosition).startsWith('return')) {
+      startPosition += 7
+      break
+    }
+
+    if (bracketCount === 0 && curlyCount === 0 && str.substring(startPosition, endPosition).startsWith('...')) {
+      startPosition += 3
+      break
+    }
+
+    startPosition--
+  }
+
+  return `${str.substring(0, startPosition)}${func.replace('@data', str.substring(startPosition, endPosition + 1)).replace('@line', str.split('\n').length)}${str.substring(endPosition + 1)}`
+}
+
+/**
+ * Find every instance of a token in a file and call inject on the string before it
+ * @param {string} file
+ * @param {RegExp} token
+ * @test #Annotations.Multiple
+ */
+export function injectStr (file, func = 'tap(@data)', token = new RegExp('\\/\\/\\s*\\?[^\\n]*', 'g')) {
+  let match = token.exec(file)
+  while (match !== null) {
+    file = inject(file.substring(0, match.index), func).replace('@expr', JSON.stringify(match[0].split('?')[1] || '@')) + file.slice(match.index + match[0].length)
+    match = token.exec(file)
+  }
+  return file
+}

--- a/annotation.js.psnap
+++ b/annotation.js.psnap
@@ -1,0 +1,26 @@
+{
+  "inject('join(dir, type)')": {
+    "value": "tap(join(dir, type))",
+    "async": false
+  },
+  "inject('path.join(dir, type)')": {
+    "value": "tap(path.join(dir, type))",
+    "async": false
+  },
+  "inject('const x = path.join(dir, type)')": {
+    "value": "const x =tap( path.join(dir, type))",
+    "async": false
+  },
+  "inject('const x = path.join(dir, type);')": {
+    "value": "const x =tap( path.join(dir, type));",
+    "async": false
+  },
+  "inject('path.join(dir,\\ntype),')": {
+    "value": "tap(path.join(dir,\ntype)),",
+    "async": false
+  },
+  "injectStr(#Annotations.Multiple)": {
+    "value": "\n        const z =tap( {\n            x: 1 \n        }) \n\n        const y =tap( 7); \n        const x =tap( 5) \n\ntap(        Math.max(1, 2, 3)) \n          ",
+    "async": false
+  }
+}

--- a/annotation.test.js
+++ b/annotation.test.js
@@ -1,0 +1,22 @@
+
+/**
+ * @pineapple_define Annotations
+ */
+export function AnnotationTests () {
+  return {
+    Multiple: `
+        const z = {
+            x: 1 
+        } // ? @.x
+
+        const y = 7; // ?
+        const x = 5 // ?
+
+        Math.max(1, 2, 3) // ?
+          `
+  }
+}
+
+// For now, the transpiler will fail if a "// ?" is contained in a string
+const trap = '// ?'
+AnnotationTests(trap)

--- a/annotationSamples.test.js
+++ b/annotationSamples.test.js
@@ -1,0 +1,14 @@
+
+/**
+ * @test { name: 'Jesse', age: 25, email: 'jesse.daniel.mitchell@gmail.com' } returns
+ * @test { name: 'Bob', age: 37, email: 'bob@bobwarehouse.com' } returns
+ */
+export function commentTap (input) {
+  return {
+    message: `Hello ${
+        input // ? @.email
+            .name
+    }`, // ?
+    success: true
+  }
+}

--- a/annotationSamples.test.js
+++ b/annotationSamples.test.js
@@ -1,9 +1,14 @@
 
+const circular = { }
+circular.circle = circular
+
 /**
  * @test { name: 'Jesse', age: 25, email: 'jesse.daniel.mitchell@gmail.com' } returns
  * @test { name: 'Bob', age: 37, email: 'bob@bobwarehouse.com' } returns
  */
 export function commentTap (input) {
+  // eslint-disable-next-line no-unused-vars
+  const circle = circular // ?
   return {
     message: `Hello ${
         input // ? @.email

--- a/annotationSamples.test.js
+++ b/annotationSamples.test.js
@@ -9,6 +9,7 @@ export function commentTap (input) {
         input // ? @.email
             .name
     }`, // ?
-    success: true
-  }
+    success: true,
+    ...input // ?
+  } // ?
 }

--- a/cli.js
+++ b/cli.js
@@ -25,7 +25,7 @@ const formatOption = new Option('-f, --format <format>', 'The output format').ch
 
 program
   .name('pineapple')
-  .version('0.18.1')
+  .version('0.18.2')
   .option('-i, --include <files...>', 'Comma separated globs of files to include.')
   .option('-e, --exclude <files...>', 'Comma separated globs of files to exclude.')
   .option('-w, --watch-mode', 'Will run tests only when a file is modified.')
@@ -40,6 +40,7 @@ program
   .option('--only <lines...>', 'Allows you to specify which tests you would like to run.')
   .option('--fuzz-runs <amount>', 'The number of runs that fuzz tests perform.', '100')
   .option('--snapshot-fuzz-runs <amount>', 'The number of runs that fuzz tests perform on a snapshot.', '10')
+  .option('--cjs', 'Forces CommonJS to be used instead of ESM. This is not always necessary, but can be useful in some cases, particularly when using TypeScript.')
   .addOption(formatOption)
 
 if (os.platform() !== 'win32') program.option('--bun', 'Uses Bun as the test runner.')
@@ -188,7 +189,8 @@ async function execute (functions, forkProcess = false) {
   // add imports
   await Promise.all(imports.map(async ([moduleSpecifier, { namedImports, original }], index) => {
     if (options.transpile) {
-      const recommended = `./pineapple-runner/${hash(moduleSpecifier)}.mjs`
+      const extension = options.cjs ? '.cjs' : '.mjs'
+      const recommended = `./pineapple-runner/${hash(moduleSpecifier)}${extension}`
       const transpileFunc = transpileFunctions.find(i => i.files.some(i =>
         minimatch(moduleSpecifier, i, { matchBase: true })
       ))?.transpile ?? transpile

--- a/experimental/scenario.test.ts
+++ b/experimental/scenario.test.ts
@@ -85,6 +85,5 @@ Then I should have eaten 80 pineapples`
   */
  export const FailsDeclaration = () => {
   Given('I have {num} pineapples in my belly', function ({ num }) {
-    this.pineapples = num
   })
  }

--- a/experimental/table.js
+++ b/experimental/table.js
@@ -2,6 +2,8 @@ import fc from 'fast-check'
 import { sequenceArbitrary } from './sequence-arbitrary.js'
 
 /**
+ * @test date() returns false
+ * @test '5' returns true
  * @param {string} str
  */
 function isNumeric (str) {

--- a/inputs.js
+++ b/inputs.js
@@ -1,6 +1,7 @@
 import chalk from 'chalk'
 import { serialize } from './snapshot.js'
 import { diff } from './utils.js'
+import { flush } from './run.js'
 
 async function getConfirmation (message) {
   if (typeof prompt !== 'undefined') {
@@ -64,6 +65,8 @@ export async function askSnapshot ({ item, rule, id, file }) {
     return false
   }
   console.log(`On test (${id.split('(')[0]}):`, rule)
+  flush()
+
   console.log(chalk.green(serialize(item)))
   const result = await getConfirmation(`${chalk.magenta('?')} Accept this snapshot?`).catch(err => console.log(err))
   return result
@@ -89,6 +92,8 @@ export async function askSnapshotUpdate ({ item, value, rule, id, file }) {
     return false
   }
   console.log(`On test (${id.split('(')[0]}):`, rule)
+  flush()
+
   console.log(diff(value, item))
   const result = await getConfirmation(`${chalk.magenta('?')} Do you wish to update to this snapshot?`)
   return result

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pineapple",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "description": "Make your testing sweet!",
   "main": "index.js",
   "scripts": {

--- a/run.js
+++ b/run.js
@@ -12,7 +12,7 @@ import url from 'url'
 import { faker } from '@faker-js/faker'
 
 // Global Log Injection //
-let currentLog = ''
+if (!global.currentLog) global.currentLog = ''
 global.log = (v, file, line, expr) => {
   let extract = i => i
   if (expr !== '@') {
@@ -23,16 +23,16 @@ global.log = (v, file, line, expr) => {
   }
 
   try {
-    currentLog += `${file}:${line}: ${serialize(extract(v))}\n`
+    global.currentLog += `${file}:${line}: ${serialize(extract(v))}\n`
   } catch (e) {
-    currentLog += `${file}:${line}: ${extract(v)}\n`
+    global.currentLog += `${file}:${line}: ${extract(v)}\n`
   }
 
   return v
 }
 export function flush () {
-  if (currentLog) console.log(currentLog)
-  currentLog = ''
+  if (global.currentLog) console.log(global.currentLog)
+  global.currentLog = ''
 }
 // End Global Log Injection //
 
@@ -233,7 +233,6 @@ export async function run (input, id, func, file) {
 
   try {
     const [data, success, message] = await internalRun(input, func)
-
     if (!success) {
       failure({ name: id, input, message, file, data })
       flush()

--- a/run.js
+++ b/run.js
@@ -10,6 +10,32 @@ import { argumentsToArbitraries } from './utils.js'
 import { always } from 'ramda'
 import url from 'url'
 import { faker } from '@faker-js/faker'
+
+// Global Log Injection //
+let currentLog = ''
+global.log = (v, file, line, expr) => {
+  let extract = i => i
+  if (expr !== '@') {
+    try {
+      const func = engine.fallback.build(parse(expr.trim(), { startRule: 'Expression' }))
+      extract = data => func({ data })
+    } catch (e) {}
+  }
+
+  try {
+    currentLog += `${file}:${line}: ${serialize(extract(v))}\n`
+  } catch (e) {
+    currentLog += `${file}:${line}: ${extract(v)}\n`
+  }
+
+  return v
+}
+export function flush () {
+  if (currentLog) console.log(currentLog)
+  currentLog = ''
+}
+// End Global Log Injection //
+
 const ArbitraryFaker = { ...faker }
 
 const snap = snapshotManager()
@@ -210,6 +236,7 @@ export async function run (input, id, func, file) {
 
     if (!success) {
       failure({ name: id, input, message, file, data })
+      flush()
       return 1
     }
   } catch (err) {
@@ -217,11 +244,13 @@ export async function run (input, id, func, file) {
       const { message } = err
       parseFailure(id, input, message, file)
     } else testRuntimeFailure(err)
+    flush()
 
     return 1
   }
 
   success(id, input, file)
+  flush()
   return 0
 }
 

--- a/typescriptTranspiler.js
+++ b/typescriptTranspiler.js
@@ -1,4 +1,14 @@
 import esbuild from 'esbuild'
+import fs from 'fs/promises'
+import path from 'path'
+import { injectStr } from './annotation.js'
+
+const loaderDict = {
+  cjs: 'js'
+}
+function replaceLoader (loader) {
+  return loaderDict[loader] || loader
+}
 
 /**
  * It takes a file path, transpiles it to JavaScript, and returns the file path to the transpiled file
@@ -7,15 +17,34 @@ import esbuild from 'esbuild'
  */
 export async function transpile (input, file) {
   /* Transpiling the file to JavaScript. */
-  await esbuild.build({
-    entryPoints: [input],
-    outfile: file,
-    sourcemap: 'inline',
-    bundle: true,
-    nodePaths: [''],
-    format: 'esm',
-    packages: 'external'
-  })
+
+  try {
+    await esbuild.build({
+      stdin: {
+        contents: injectStr(await fs.readFile(input, 'utf-8'), `global.log(@data, "${input}", @line, @expr)`),
+        sourcefile: input,
+        resolveDir: path.dirname(input),
+        loader: replaceLoader(path.extname(input).slice(1))
+      },
+      outfile: file,
+      sourcemap: 'inline',
+      bundle: true,
+      nodePaths: [''],
+      format: file.endsWith('cjs') ? 'cjs' : 'esm',
+      packages: 'external',
+      logLevel: 'silent'
+    })
+  } catch (err) {
+    await esbuild.build({
+      entryPoints: [input],
+      outfile: file,
+      sourcemap: 'inline',
+      bundle: true,
+      nodePaths: [''],
+      format: file.endsWith('cjs') ? 'cjs' : 'esm',
+      packages: 'external'
+    })
+  }
 
   return file
 }


### PR DESCRIPTION
# Enhanced Logging

Similar to Quokka.js, Pineapple will allow you to add annotations to your code to help get logging output during test execution. 

```js
/**
 * @test 'Jesse', 12
 * @test 'Joe', '15'
 * @param {string} owner
 * @param {number} length
 */
export async function createRental (owner, length, type = 'boat') {
  assert(typeof owner === 'string', 'Owner must be a string.')
  assert(typeof length === 'number', 'Length must be a number.')
  return {
    type,
    owner,
    length
  } // ?
} 
```

Will log:
```
/Users/jesse/Documents/Projects/pineapple/test/rental.js:16: {
  "type": "boat",
  "owner": "Jesse",
  "length": 12
}
```

The implementation is mildly brittle, but the code footprint is small. It should work for most general use cases, namely:
- On return statements,
- On a single line inside an object / array,
- On an assignment
- Inside a ternary
- On an argument of a function on its own line
- On a function call

You can also drill down / do some computation similar to what you can write in test cases:
```javascript
/**
 * @test 'Jesse', 12
 * @test 'Joe', '15'
 * @param {string} owner
 * @param {number} length
 */
export async function createRental (owner, length, type = 'boat') {
  assert(typeof owner === 'string', 'Owner must be a string.')
  assert(typeof length === 'number', 'Length must be a number.')
  return {
    type,
    owner,
    length
  } // ? @.owner
}
```

Will log

```
/Users/jesse/Documents/Projects/pineapple/test/rental.js:16: "Jesse"
```

This also works with functions you've imported into Pineapple,

```
// ? double(@.owner)
```

Could produce

```
/Users/jesse/Documents/Projects/pineapple/test/rental.js:16: "JesseJesse"
```