### PR TITLE
Add more arbitraries and omissions

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -25,7 +25,7 @@ const formatOption = new Option('-f, --format <format>', 'The output format').ch
 
 program
   .name('pineapple')
-  .version('0.20.3')
+  .version('0.21.0')
   .option('-i, --include <files...>', 'Comma separated globs of files to include.')
   .option('-e, --exclude <files...>', 'Comma separated globs of files to exclude.')
   .option('-w, --watch-mode', 'Will run tests only when a file is modified.')

--- a/inputs.js
+++ b/inputs.js
@@ -2,20 +2,23 @@ import chalk from 'chalk'
 import { serialize } from './snapshot.js'
 import { diff } from './utils.js'
 import { flush } from './run.js'
+import { getDiff } from 'json-difference'
 
-async function getConfirmation (message) {
+async function getConfirmation (message, choices = ['Yes', 'No ']) {
   if (typeof prompt !== 'undefined') {
     const result = prompt(`${message} (Y/N)`).toLowerCase()
     console.log()
-    return result === 'y' || result === 'yes'
+    return result === 'y' || result === 'yes' ? 'Yes' : 'No '
   }
   return new Promise(resolve => {
     const currentMode = process.stdin.isRaw
     if (process.stdin.setRawMode) process.stdin.setRawMode(true)
 
     process.stdout.write(message + ' ')
-    let choice = true
-    process.stdout.write('Yes')
+    let choice = choices[0]
+    process.stdout.write(choices[0])
+
+    let position = 0
 
     const func = data => {
       if (data[0] === 13) {
@@ -30,15 +33,19 @@ async function getConfirmation (message) {
       if (data === '\x1B[B') {
         process.stdout.write('\r')
         process.stdout.write(message + ' ')
-        process.stdout.write('No ')
-        choice = false
+        position++
+        if (position >= choices.length) position = 0
+        process.stdout.write(choices[position])
+        choice = choices[position]
       }
 
       if (data === '\x1B[A') {
         process.stdout.write('\r')
         process.stdout.write(message + ' ')
-        process.stdout.write('Yes')
-        choice = true
+        position--
+        if (position < 0) position = choices.length - 1
+        process.stdout.write(choices[position])
+        choice = choices[position]
       }
     }
 
@@ -95,6 +102,19 @@ export async function askSnapshotUpdate ({ item, value, rule, id, file }) {
   flush()
 
   console.log(diff(value, item))
+
+  if (typeof value === typeof item && value && item && typeof value === 'object') {
+    const differences = getDiff(value, item, true)
+    if (differences.added.length === 0 && differences.removed.length === 0) {
+      // This means that fields were modified, which means we can offer to omit the fields
+      console.log(chalk.yellow('\nSome of the fields have been modified, you can choose to omit them.'))
+
+      const result = await getConfirmation(`${chalk.magenta('?')} Do you wish to update to this snapshot?`, ['Yes ', 'No  ', 'Omit'])
+      if (result === 'Omit') return { omitDeep: [{ var: '' }, differences.edited.map(i => i[0])] }
+      return result === 'Yes '
+    }
+  }
+
   const result = await getConfirmation(`${chalk.magenta('?')} Do you wish to update to this snapshot?`)
-  return result
+  return result === 'Yes'
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "debounce": "^1.2.1",
     "dependency-tree": "^8.1.2",
     "esbuild": "^0.16.10",
-    "fast-check": "^3.3.0",
+    "fast-check": "^3.10.0",
     "glob": "^8.0.3",
     "jest-diff": "^27.5.1",
     "json-difference": "^1.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pineapple",
-  "version": "0.20.3",
+  "version": "0.21.0",
   "description": "Make your testing sweet!",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "fast-check": "^3.3.0",
     "glob": "^8.0.3",
     "jest-diff": "^27.5.1",
+    "json-difference": "^1.9.1",
     "json-logic-engine": "^1.2.6",
     "ramda": "^0.28.0",
     "ramda-adjunct": "^3.0.0",

--- a/parser/grammar.pegjs
+++ b/parser/grammar.pegjs
@@ -278,7 +278,10 @@ ArithmeticExpression0
   / NonArithmeticExpression
 
 FunctionCall
-  = _ id:Identifier _ '(' _ args:FunctionArgs _ ').' getId:Identifier {
+  = _ '#' id:Identifier _ '(' _ args:FunctionArgs _ ').' getId:Identifier {
+    return { get: [{ ['#' + id]: args.length <= 1 ? args[0] : args }, getId] }
+  }
+  / _ id:Identifier _ '(' _ args:FunctionArgs _ ').' getId:Identifier {
     return { get: [{ [id]: args.length <= 1 ? args[0] : args }, getId] }
   }
   / _ '#' id:Identifier _ '(' _ args:FunctionArgs _ ')' {

--- a/run.js
+++ b/run.js
@@ -7,10 +7,27 @@ import { SpecialHoF, ConstantFunc } from './symbols.js'
 import { failure, parseFailure, success, testRuntimeFailure, snapshotsUnused } from './outputs.js'
 import fc from 'fast-check'
 import { argumentsToArbitraries } from './utils.js'
-import { always } from 'ramda'
+import { always, once } from 'ramda'
 import url from 'url'
+
 // Todo: Add support for other locales.
 import { Faker, en } from '@faker-js/faker'
+
+const init = once(() => {
+  // Adding in each of the Faker Methods as Arbitrary Generators
+  const realms = Object.keys(ArbitraryFaker).filter(i => !i.startsWith('_') && !i.includes('efinition') && !i.includes('helpers'))
+  for (const realm of realms) {
+    const definitions = Object.keys(ArbitraryFaker[realm]).reduce((acc, method) => {
+      const fn = ArbitraryFaker[realm][method]
+      if (typeof fn === 'function') {
+        const key = `${realm}.${method}`
+        acc[key] = (...args) => fc.nat().noShrink().map(() => fn(...args))
+      }
+      return acc
+    }, {})
+    addDefinitions(() => definitions)
+  }
+})
 
 // Global Log Injection //
 if (!global.currentLog) global.currentLog = ''
@@ -57,8 +74,21 @@ function snapshotManager () {
     const tests = []
     for (const file in snapshots) {
       const remaining = await snapshots[file].notAccessed
-      if (mode === 'clean') for (const item of Array.from(remaining)) await snapshots[file].remove(item)
-      else if (remaining.size) tests.push(...Array.from(remaining).map(item => [file, item]))
+      if (mode === 'clean') {
+        for (const item of Array.from(remaining).filter(i => {
+          if (i.endsWith('.transform')) {
+            // todo: make this clean up when the original is gone from the snapshot via manual edit
+            return remaining.has(
+              i.substring(0, i.lastIndexOf('.transform'))
+            )
+          }
+          return true
+        })) await snapshots[file].remove(item)
+      } else if (remaining.size) {
+        tests.push(...Array.from(remaining).map(item => [file, item]).filter(([, item]) => {
+          return !item.endsWith('.transform')
+        }))
+      }
     }
 
     if (tests.length) {
@@ -149,6 +179,9 @@ class FuzzError extends Error {
  * @param {string} file
  */
 export async function run (input, id, func, file) {
+  // This will run any necessary setup code.
+  init()
+
   /**
      * @param {string} input
      * @param {string} id

--- a/run.js
+++ b/run.js
@@ -76,17 +76,17 @@ function snapshotManager () {
       const remaining = await snapshots[file].notAccessed
       if (mode === 'clean') {
         for (const item of Array.from(remaining).filter(i => {
-          if (i.endsWith('.transform')) {
+          if (i.endsWith('.meta')) {
             // todo: make this clean up when the original is gone from the snapshot via manual edit
             return remaining.has(
-              i.substring(0, i.lastIndexOf('.transform'))
+              i.substring(0, i.lastIndexOf('.meta'))
             )
           }
           return true
         })) await snapshots[file].remove(item)
       } else if (remaining.size) {
         tests.push(...Array.from(remaining).map(item => [file, item]).filter(([, item]) => {
-          return !item.endsWith('.transform')
+          return !item.endsWith('.meta')
         }))
       }
     }

--- a/snapshot.js
+++ b/snapshot.js
@@ -23,16 +23,16 @@ export function snapshot (file = './pineapple-snapshot') {
     return {
       exists: key in (await data),
       value: (await data)[key],
-      transform: (await data)[`${key}.transform`]
+      meta: (await data)[`${key}.meta`]
     }
   }
 
   // todo: make this not hammer disk.
-  const set = async function (key, value, transform) {
+  const set = async function (key, value, meta) {
     if (!this.data) this.data = await data
     this.data[key] = value
-    if (transform) this.data[`${key}.transform`] = transform
-    else if (this.data[`${key}.transform`]) delete this.data[`${key}.transform`]
+    if (meta) this.data[`${key}.meta`] = meta
+    else if (this.data[`${key}.meta`]) delete this.data[`${key}.meta`]
     await fs.writeFile(file, serialize(this.data))
   }
 

--- a/snapshot.js
+++ b/snapshot.js
@@ -22,14 +22,17 @@ export function snapshot (file = './pineapple-snapshot') {
     (await notAccessed).delete(key)
     return {
       exists: key in (await data),
-      value: (await data)[key]
+      value: (await data)[key],
+      transform: (await data)[`${key}.transform`]
     }
   }
 
   // todo: make this not hammer disk.
-  const set = async function (key, value) {
+  const set = async function (key, value, transform) {
     if (!this.data) this.data = await data
     this.data[key] = value
+    if (transform) this.data[`${key}.transform`] = transform
+    else if (this.data[`${key}.transform`]) delete this.data[`${key}.transform`]
     await fs.writeFile(file, serialize(this.data))
   }
 

--- a/test/faker.ts
+++ b/test/faker.ts
@@ -52,3 +52,12 @@ export function register(user: User) {
         message: `Welcome ${user.username}!`
     }
 }
+
+/**
+ * Making use of faker's helpers.
+ * @test #person.fullName returns cat('Hi ', args.0, '!')
+ * @test #airline.airline().name returns cat("Hi ", args.0, "!")
+ */
+export function sayHi(name: string) {
+    return `Hi ${name}!`
+}

--- a/test/rental.js
+++ b/test/rental.js
@@ -15,6 +15,7 @@ export async function createRental (owner, length, type = 'boat') {
   return {
     type,
     owner,
-    length
+    length,
+    createdAt: new Date()
   }
 }

--- a/test/rental.js
+++ b/test/rental.js
@@ -16,6 +16,6 @@ export async function createRental (owner, length, type = 'boat') {
     type,
     owner,
     length,
-    createdAt: new Date()
+    date: new Date().getTime()
   }
 }

--- a/test/rental.js.psnap
+++ b/test/rental.js.psnap
@@ -4,7 +4,7 @@
       "type": "boat",
       "owner": "Jesse",
       "length": 12,
-      "createdAt": date("2023-06-08T17:37:51.793Z")
+      "date": 1686255135217
     },
     "async": true
   },
@@ -21,7 +21,7 @@
     "value": {
       "type": "boat",
       "owner": "Jesse",
-      "createdAt": date("2023-06-08T17:37:53.035Z")
+      "date": 1686255137098
     },
     "async": true
   },
@@ -31,24 +31,64 @@
     },
     "async": true
   },
-  "createRental('Jesse', 12).transform": {
-    "omitDeep": [
-      {
-        "var": ""
-      },
-      [
-        "value.createdAt"
+  "createRental('Jesse', 12).meta": {
+    "transform": {
+      "omitDeep": [
+        {
+          "var": ""
+        },
+        [
+          "value.date"
+        ]
       ]
-    ]
+    },
+    "check": {
+      "and": [
+        {
+          "===": [
+            {
+              "typeof": {
+                "var": "actual.value.date"
+              }
+            },
+            {
+              "typeof": {
+                "var": "expected.value.date"
+              }
+            }
+          ]
+        }
+      ]
+    }
   },
-  "createRental('Jesse', 14 snapshot omit(['length'], @)).transform": {
-    "omitDeep": [
-      {
-        "var": ""
-      },
-      [
-        "value.createdAt"
+  "createRental('Jesse', 14 snapshot omit(['length'], @)).meta": {
+    "transform": {
+      "omitDeep": [
+        {
+          "var": ""
+        },
+        [
+          "value.date"
+        ]
       ]
-    ]
+    },
+    "check": {
+      "and": [
+        {
+          "===": [
+            {
+              "typeof": {
+                "var": "actual.value.date"
+              }
+            },
+            {
+              "typeof": {
+                "var": "expected.value.date"
+              }
+            }
+          ]
+        }
+      ]
+    }
   }
 }

--- a/test/rental.js.psnap
+++ b/test/rental.js.psnap
@@ -3,7 +3,8 @@
     "value": {
       "type": "boat",
       "owner": "Jesse",
-      "length": 12
+      "length": 12,
+      "createdAt": date("2023-06-08T17:37:51.793Z")
     },
     "async": true
   },
@@ -19,7 +20,8 @@
   "createRental('Jesse', 14 snapshot omit(['length'], @))": {
     "value": {
       "type": "boat",
-      "owner": "Jesse"
+      "owner": "Jesse",
+      "createdAt": date("2023-06-08T17:37:53.035Z")
     },
     "async": true
   },
@@ -28,5 +30,25 @@
       "length": 14
     },
     "async": true
+  },
+  "createRental('Jesse', 12).transform": {
+    "omitDeep": [
+      {
+        "var": ""
+      },
+      [
+        "value.createdAt"
+      ]
+    ]
+  },
+  "createRental('Jesse', 14 snapshot omit(['length'], @)).transform": {
+    "omitDeep": [
+      {
+        "var": ""
+      },
+      [
+        "value.createdAt"
+      ]
+    ]
   }
 }

--- a/test/snapshot-with-changing.js
+++ b/test/snapshot-with-changing.js
@@ -1,0 +1,17 @@
+
+/**
+ * @test #person.fullName
+ */
+export function changing () {
+  return {
+    date: new Date().getTime()
+  }
+}
+
+/**
+ * @test #boolean
+ */
+export function TruthyTest (a) {
+  if (a) return Math.random() + 1
+  return null
+}

--- a/test/snapshot-with-changing.js.psnap
+++ b/test/snapshot-with-changing.js.psnap
@@ -1,0 +1,582 @@
+{
+  "changing(#person.fullName)": {
+    "value": {
+      "date": 1686255163259
+    },
+    "async": false,
+    "input": [
+      "Julia Grady"
+    ]
+  },
+  "changing(#person.fullName).2": {
+    "value": {
+      "date": 1686255167447
+    },
+    "async": false,
+    "input": [
+      "Adrian Blanda"
+    ]
+  },
+  "changing(#person.fullName).3": {
+    "value": {
+      "date": 1686255168366
+    },
+    "async": false,
+    "input": [
+      "Connie Johnston"
+    ]
+  },
+  "changing(#person.fullName).4": {
+    "value": {
+      "date": 1686255169188
+    },
+    "async": false,
+    "input": [
+      "Lauren Homenick"
+    ]
+  },
+  "changing(#person.fullName).5": {
+    "value": {
+      "date": 1686255170709
+    },
+    "async": false,
+    "input": [
+      "Lester Rath"
+    ]
+  },
+  "changing(#person.fullName).6": {
+    "value": {
+      "date": 1686255171574
+    },
+    "async": false,
+    "input": [
+      "Essie Legros"
+    ]
+  },
+  "changing(#person.fullName).7": {
+    "value": {
+      "date": 1686255172433
+    },
+    "async": false,
+    "input": [
+      "Alfred Gibson"
+    ]
+  },
+  "changing(#person.fullName).8": {
+    "value": {
+      "date": 1686255173186
+    },
+    "async": false,
+    "input": [
+      "Alfonso Ledner"
+    ]
+  },
+  "changing(#person.fullName).9": {
+    "value": {
+      "date": 1686255173947
+    },
+    "async": false,
+    "input": [
+      "Clifton Kiehn"
+    ]
+  },
+  "changing(#person.fullName).10": {
+    "value": {
+      "date": 1686255174762
+    },
+    "async": false,
+    "input": [
+      "Elaine Botsford"
+    ]
+  },
+  "TruthyTest(#boolean)": {
+    "value": null,
+    "async": false,
+    "input": [
+      false
+    ]
+  },
+  "TruthyTest(#boolean).2": {
+    "value": 1.9989062278384333,
+    "async": false,
+    "input": [
+      true
+    ]
+  },
+  "TruthyTest(#boolean).3": {
+    "value": null,
+    "async": false,
+    "input": [
+      false
+    ]
+  },
+  "TruthyTest(#boolean).4": {
+    "value": null,
+    "async": false,
+    "input": [
+      false
+    ]
+  },
+  "TruthyTest(#boolean).5": {
+    "value": null,
+    "async": false,
+    "input": [
+      false
+    ]
+  },
+  "TruthyTest(#boolean).6": {
+    "value": null,
+    "async": false,
+    "input": [
+      false
+    ]
+  },
+  "TruthyTest(#boolean).7": {
+    "value": null,
+    "async": false,
+    "input": [
+      false
+    ]
+  },
+  "TruthyTest(#boolean).8": {
+    "value": 1.930991211471164,
+    "async": false,
+    "input": [
+      true
+    ]
+  },
+  "TruthyTest(#boolean).9": {
+    "value": 1.7576144710731985,
+    "async": false,
+    "input": [
+      true
+    ]
+  },
+  "TruthyTest(#boolean).10": {
+    "value": 1.3533316207277866,
+    "async": false,
+    "input": [
+      true
+    ]
+  },
+  "changing(#person.fullName).meta": {
+    "transform": {
+      "omitDeep": [
+        {
+          "var": ""
+        },
+        [
+          "value.date"
+        ]
+      ]
+    },
+    "check": {
+      "and": [
+        {
+          "===": [
+            {
+              "typeof": {
+                "var": "actual.value.date"
+              }
+            },
+            {
+              "typeof": {
+                "var": "expected.value.date"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "changing(#person.fullName).2.meta": {
+    "transform": {
+      "omitDeep": [
+        {
+          "var": ""
+        },
+        [
+          "value.date"
+        ]
+      ]
+    },
+    "check": {
+      "and": [
+        {
+          "===": [
+            {
+              "typeof": {
+                "var": "actual.value.date"
+              }
+            },
+            {
+              "typeof": {
+                "var": "expected.value.date"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "changing(#person.fullName).3.meta": {
+    "transform": {
+      "omitDeep": [
+        {
+          "var": ""
+        },
+        [
+          "value.date"
+        ]
+      ]
+    },
+    "check": {
+      "and": [
+        {
+          "===": [
+            {
+              "typeof": {
+                "var": "actual.value.date"
+              }
+            },
+            {
+              "typeof": {
+                "var": "expected.value.date"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "changing(#person.fullName).4.meta": {
+    "transform": {
+      "omitDeep": [
+        {
+          "var": ""
+        },
+        [
+          "value.date"
+        ]
+      ]
+    },
+    "check": {
+      "and": [
+        {
+          "===": [
+            {
+              "typeof": {
+                "var": "actual.value.date"
+              }
+            },
+            {
+              "typeof": {
+                "var": "expected.value.date"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "changing(#person.fullName).5.meta": {
+    "transform": {
+      "omitDeep": [
+        {
+          "var": ""
+        },
+        [
+          "value.date"
+        ]
+      ]
+    },
+    "check": {
+      "and": [
+        {
+          "===": [
+            {
+              "typeof": {
+                "var": "actual.value.date"
+              }
+            },
+            {
+              "typeof": {
+                "var": "expected.value.date"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "changing(#person.fullName).6.meta": {
+    "transform": {
+      "omitDeep": [
+        {
+          "var": ""
+        },
+        [
+          "value.date"
+        ]
+      ]
+    },
+    "check": {
+      "and": [
+        {
+          "===": [
+            {
+              "typeof": {
+                "var": "actual.value.date"
+              }
+            },
+            {
+              "typeof": {
+                "var": "expected.value.date"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "changing(#person.fullName).7.meta": {
+    "transform": {
+      "omitDeep": [
+        {
+          "var": ""
+        },
+        [
+          "value.date"
+        ]
+      ]
+    },
+    "check": {
+      "and": [
+        {
+          "===": [
+            {
+              "typeof": {
+                "var": "actual.value.date"
+              }
+            },
+            {
+              "typeof": {
+                "var": "expected.value.date"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "changing(#person.fullName).8.meta": {
+    "transform": {
+      "omitDeep": [
+        {
+          "var": ""
+        },
+        [
+          "value.date"
+        ]
+      ]
+    },
+    "check": {
+      "and": [
+        {
+          "===": [
+            {
+              "typeof": {
+                "var": "actual.value.date"
+              }
+            },
+            {
+              "typeof": {
+                "var": "expected.value.date"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "changing(#person.fullName).9.meta": {
+    "transform": {
+      "omitDeep": [
+        {
+          "var": ""
+        },
+        [
+          "value.date"
+        ]
+      ]
+    },
+    "check": {
+      "and": [
+        {
+          "===": [
+            {
+              "typeof": {
+                "var": "actual.value.date"
+              }
+            },
+            {
+              "typeof": {
+                "var": "expected.value.date"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "changing(#person.fullName).10.meta": {
+    "transform": {
+      "omitDeep": [
+        {
+          "var": ""
+        },
+        [
+          "value.date"
+        ]
+      ]
+    },
+    "check": {
+      "and": [
+        {
+          "===": [
+            {
+              "typeof": {
+                "var": "actual.value.date"
+              }
+            },
+            {
+              "typeof": {
+                "var": "expected.value.date"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "TruthyTest(#boolean).2.meta": {
+    "transform": {
+      "omitDeep": [
+        {
+          "var": ""
+        },
+        [
+          "value"
+        ]
+      ]
+    },
+    "check": {
+      "and": [
+        {
+          "===": [
+            {
+              "!!": {
+                "var": "actual.value"
+              }
+            },
+            {
+              "!!": {
+                "var": "expected.value"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "TruthyTest(#boolean).8.meta": {
+    "transform": {
+      "omitDeep": [
+        {
+          "var": ""
+        },
+        [
+          "value"
+        ]
+      ]
+    },
+    "check": {
+      "and": [
+        {
+          "===": [
+            {
+              "!!": {
+                "var": "actual.value"
+              }
+            },
+            {
+              "!!": {
+                "var": "expected.value"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "TruthyTest(#boolean).9.meta": {
+    "transform": {
+      "omitDeep": [
+        {
+          "var": ""
+        },
+        [
+          "value"
+        ]
+      ]
+    },
+    "check": {
+      "and": [
+        {
+          "===": [
+            {
+              "!!": {
+                "var": "actual.value"
+              }
+            },
+            {
+              "!!": {
+                "var": "expected.value"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "TruthyTest(#boolean).10.meta": {
+    "transform": {
+      "omitDeep": [
+        {
+          "var": ""
+        },
+        [
+          "value"
+        ]
+      ]
+    },
+    "check": {
+      "and": [
+        {
+          "===": [
+            {
+              "!!": {
+                "var": "actual.value"
+              }
+            },
+            {
+              "!!": {
+                "var": "expected.value"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/utils.js
+++ b/utils.js
@@ -1,5 +1,5 @@
 import chalk from 'chalk'
-import { diff as jestDiff } from 'jest-diff'
+import { diffStringsUnified } from 'jest-diff'
 import engine from './methods.js'
 import { serialize } from './snapshot.js'
 import fc from 'fast-check'
@@ -29,10 +29,18 @@ function checkConstantFunction (name) {
  * @returns The function diffTouchup is being returned.
  */
 export function diff (expected, received) {
-  const result = jestDiff(expected, received)
-  if (result.includes('Comparing two different types')) {
-    return `${result}\n  ${chalk.green(`- Expected: ${serialize(expected).replace(/\n/g, '\n  ')}`)}\n${chalk.red(`  - Received: ${serialize(received).replace(/\n/g, '\n  ')}`)}`
+  if (typeof expected !== typeof received) {
+    return `Comparing two different types of values. Expected ${chalk.green(typeof expected)} but received ${chalk.red(typeof received)}.\n${chalk.green(`- Expected: ${serialize(expected).replace(/\n/g, '\n  ')}`)}\n${chalk.red(`- Received: ${serialize(received).replace(/\n/g, '\n  ')}`)}`
   }
+
+  const result = diffStringsUnified(
+    serialize(expected),
+    serialize(received),
+    {
+      changeColor: i => i
+    }
+  )
+
   return result
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1748,6 +1748,11 @@ js-yaml@^3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+json-difference@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/json-difference/-/json-difference-1.9.1.tgz#648aa806da2e3c4b7db24c34f6b04963b542fec2"
+  integrity sha512-5c2xaHKMkTq6T9KfCh4r3PVHQObpOyKMZzrySCAoYPBYJ0VqKDUW7dioddKLNS9z4Jey7yyMNSTH3bNF95Z1Nw==
+
 json-logic-engine@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/json-logic-engine/-/json-logic-engine-1.2.6.tgz#51e1e85746c60d76bbe78ae4ba35b80842a2dfbe"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1149,12 +1149,12 @@ exitzero@^1.0.1:
   resolved "https://registry.npmjs.org/exitzero/-/exitzero-1.0.1.tgz"
   integrity sha1-DaZ688irExdo2q82HzOxotIxohs=
 
-fast-check@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.npmjs.org/fast-check/-/fast-check-3.3.0.tgz"
-  integrity sha512-Zu6tZ4g0T4H9Tiz3tdNPEHrSbuICj7yhdOM9RCZKNMkpjZ9avDV3ORklXaEmh4zvkX24/bGZ9DxKKqWfXttUqw==
+fast-check@^3.10.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/fast-check/-/fast-check-3.10.0.tgz#dccdf925c123f65910754454118ff3d6461b1733"
+  integrity sha512-I2FldZwnCbcY6iL+H0rp9m4D+O3PotuFu9FasWjMCzUedYHMP89/37JbSt6/n7Yq/IZmJDW0B2h30sPYdzrfzw==
   dependencies:
-    pure-rand "^5.0.2"
+    pure-rand "^6.0.0"
 
 fast-deep-equal@^3.1.1:
   version "3.1.3"
@@ -2337,10 +2337,10 @@ punycode@^2.1.0:
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-pure-rand@^5.0.2:
-  version "5.0.3"
-  resolved "https://registry.npmjs.org/pure-rand/-/pure-rand-5.0.3.tgz"
-  integrity sha512-9N8x1h8dptBQpHyC7aZMS+iNOAm97WMGY0AFrguU1cpfW3I5jINkWe5BIY5md0ofy+1TCIELsVcm/GJXZSaPbw==
+pure-rand@^6.0.0:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-6.0.2.tgz#a9c2ddcae9b68d736a8163036f088a2781c8b306"
+  integrity sha512-6Yg0ekpKICSjPswYOuC5sku/TSWaRYlA0qsXqJgM/d/4pLPHPuTxK7Nbf7jFKzAeedUhR8C7K9Uv63FBsSo8xQ==
 
 queue-microtask@^1.2.2:
   version "1.2.3"


### PR DESCRIPTION

## Arbitraries

I've decided to implement support for the Faker.js functions as arbitraries in Pineapple.

```javascript
/**
 * @test #person.fullName
 */
function sayHi (name) {
  return `Hi ${name}!`
}
```

Also when you wish to extract information from an arbitrary, it works as intended.
```javascript
/**
 * @test #airline.airline().name
 */
```

`#airline.airline.name` would not work as it would interpret that as an arbitrary, so you can't use the no arguments syntax.

## Omits 

I decided to add support for omissions in the snapshots. So for fields that change in the returned object, you can choose to select `Omit` as a choice upon the next snapshot, and it will not include it in the equality check.